### PR TITLE
Fix non-UTF-8 error in nsentence()

### DIFF
--- a/R/corpus.R
+++ b/R/corpus.R
@@ -1115,7 +1115,11 @@ nsentence <- function(x, ...) {
 #' @rdname nsentence
 #' @export
 nsentence.character <- function(x, ...) {
-    if (!any(stringi::stri_detect_charclass(x, "[A-Z]")))
+upcase <- try(any(stringi::stri_detect_charclass(x, "[A-Z]")), silent = TRUE)
+    if (!is.logical(upcase)) {
+        warning("Input text contains non-UTF-8 characters.")
+    }
+    else if (!upcase)
         warning("nsentence() does not correctly count sentences in all lower-cased text")
     lengths(tokenize(x, what = "sentence", ...))
 }


### PR DESCRIPTION
Currently fails on summary(ukManifestos) due to Latin-1 characters in text 49 (UK_natl_1997_en_SEP).