### PR TITLE
Improve performance of rbind.dfm

### DIFF
--- a/R/dfm-classes.R
+++ b/R/dfm-classes.R
@@ -603,7 +603,7 @@ rbind.dfm <- function(...) {
 }
 
 
-rbind2.dfm <- function(x, y) {
+rbind2.dfm.old <- function(x, y) {
     x.names <- features(x)
     y.names <- features(y)
 

--- a/R/dfm-classes.R
+++ b/R/dfm-classes.R
@@ -605,6 +605,11 @@ rbind.dfm <- function(...) {
 combineDfms <- function(x, y) {
     x.names <- features(x)
     y.names <- features(y)
+
+      if (identical(x.names, y.names)) {
+          return(new("dfmSparse", Matrix::rbind2(x, y)))
+      }
+
     all.names <- union(x.names, y.names)
     
     toAddx <- setdiff(all.names, x.names)

--- a/R/dfm-classes.R
+++ b/R/dfm-classes.R
@@ -589,11 +589,12 @@ rbind.dfm <- function(...) {
 
     if (length(args) == 1) {
         warning('rbind.dfm called on single dfm')
-        return(args[[1]])
+        return(args[[1]][, order(features(args[[1]]))])
     }
     else if (length(args) == 2) {
         return(rbind2.dfm(args[[1]], args[[2]]))
     } else {
+        # Recursive call
         result <- rbind2.dfm(args[[1]], args[[2]])
         for (y in args[3:length(args)]) 
             result <- rbind2.dfm(result, y)

--- a/R/dfm-classes.R
+++ b/R/dfm-classes.R
@@ -602,7 +602,41 @@ rbind.dfm <- function(...) {
     }
 }
 
+rbind2.dfm <- function(x, y) {
+    x_names <- features(x)
+    y_names <- features(y)
 
+      if (identical(x_names, y_names)) {
+          return(new("dfmSparse", Matrix::rbind2(x, y)))
+      }
+
+    common_names <- intersect(x_names, y_names)
+
+    only_x_names <- setdiff(x_names, y_names)
+    only_y_names <- setdiff(y_names, x_names)
+
+    # This is kinda unreadable, sorry
+    new_dfm <- new("dfmSparse", Matrix::rbind2(
+        Matrix::cbind2(
+            Matrix::cbind2(
+                x[, common_names],
+                x[, only_x_names]
+            ),
+            Matrix::sparseMatrix(i = NULL, j = NULL, dims = c(ndoc(x), 
+                length(only_y_names)), dimnames = list(NULL, only_y_names))
+        ),
+        Matrix::cbind2(
+            Matrix::cbind2(
+                y[, common_names],
+                Matrix::sparseMatrix(i = NULL, j = NULL, dims = c(ndoc(y), 
+                    length(only_x_names)), dimnames = list(NULL, only_x_names))
+            ),
+                y[, only_y_names]
+            )
+    )
+    )
+    new_dfm[, order(features(new_dfm))]
+}
 rbind2.dfm.old <- function(x, y) {
     x.names <- features(x)
     y.names <- features(y)

--- a/R/dfm-classes.R
+++ b/R/dfm-classes.R
@@ -586,7 +586,12 @@ rbind.dfm <- function(...) {
     if (!all(sapply(args, is.dfm)))
         stop("all arguments must be dfm objects")
     cat(names(args))
-    if (length(args) <= 2) {
+
+    if (length(args) == 1) {
+        warning('rbind.dfm called on single dfm')
+        return(args[[1]])
+    }
+    else if (length(args) == 2) {
         return(combineDfms(args[[1]], args[[2]]))
     } else {
         result <- combineDfms(args[[1]], args[[2]])

--- a/R/dfm-classes.R
+++ b/R/dfm-classes.R
@@ -566,11 +566,9 @@ cbind.dfm <- function(...) {
 #' @details  \code{rbind(x, y, ...)} combines dfm objects by rows, returning a dfm
 #'   object with combined features from input dfm objects.  Features are matched
 #'   between the two dfm objects, so that the order and names of the features
-#'   does not need to match.  The resulting row combined dfm will have its
-#'   features alphabetically sorted.  The matching is performed by 
-#'   \code{\link{rbind2}} defined for object classes in the \pkg{Matrix} 
-#'   package.  The attributes and settings of this new dfm are not currently 
-#'   preserved.
+#'   do not need to match.  The order of the features in the resulting dfm
+#'   is not guaranteed.  The attributes and settings of this new dfm are not
+#'   currently preserved.
 #' @export
 #' @method rbind dfm
 #' @examples 
@@ -589,7 +587,7 @@ rbind.dfm <- function(...) {
 
     if (length(args) == 1) {
         warning('rbind.dfm called on single dfm')
-        return(new("dfmSparse", args[[1]][, order(features(args[[1]]))]))
+        return(args[[1]])
     }
     else if (length(args) == 2) {
         return(rbind2.dfm(args[[1]], args[[2]]))
@@ -615,6 +613,13 @@ rbind2.dfm <- function(x, y) {
     only_x_names <- setdiff(x_names, y_names)
     only_y_names <- setdiff(y_names, x_names)
 
+    #  Evetually, we want to rbind together two rows with the same columns
+    #  we acheive this by re-ordering the columns in the original matrices, and adding
+    #  in some blank ones
+
+    #  Here's what we're constructing:
+    #  row x ... <columns in both x and y> ... <columns only in x> ... <blank columns>
+    #  row y ... <columns in both x and y> ... <blank columns>     ... <columns only in y>
     xcols <- Matrix::cbind2(
                 x[, common_names],
                 x[, only_x_names]
@@ -630,13 +635,10 @@ rbind2.dfm <- function(x, y) {
                 empty_xcols
             )
 
-    # This is kinda unreadable, sorry
     new_dfm <- new("dfmSparse", Matrix::rbind2(
         Matrix::cbind2( xcols, empty_ycols),
         Matrix::cbind2( y_with_xcols, y[, only_y_names])
     ))
-
-    new_dfm[, order(features(new_dfm))]
 }
 
 rbind2.dfm.old <- function(x, y) {

--- a/R/dfm-classes.R
+++ b/R/dfm-classes.R
@@ -592,17 +592,17 @@ rbind.dfm <- function(...) {
         return(args[[1]])
     }
     else if (length(args) == 2) {
-        return(combineDfms(args[[1]], args[[2]]))
+        return(rbind2.dfm(args[[1]], args[[2]]))
     } else {
-        result <- combineDfms(args[[1]], args[[2]])
+        result <- rbind2.dfm(args[[1]], args[[2]])
         for (y in args[3:length(args)]) 
-            result <- combineDfms(result, y)
+            result <- rbind2.dfm(result, y)
         return(result)
     }
 }
 
 
-combineDfms <- function(x, y) {
+rbind2.dfm <- function(x, y) {
     x.names <- features(x)
     y.names <- features(y)
 

--- a/R/dfm-classes.R
+++ b/R/dfm-classes.R
@@ -589,7 +589,7 @@ rbind.dfm <- function(...) {
 
     if (length(args) == 1) {
         warning('rbind.dfm called on single dfm')
-        return(args[[1]][, order(features(args[[1]]))])
+        return(new("dfmSparse", args[[1]][, order(features(args[[1]]))]))
     }
     else if (length(args) == 2) {
         return(rbind2.dfm(args[[1]], args[[2]]))

--- a/R/dfm-classes.R
+++ b/R/dfm-classes.R
@@ -615,28 +615,30 @@ rbind2.dfm <- function(x, y) {
     only_x_names <- setdiff(x_names, y_names)
     only_y_names <- setdiff(y_names, x_names)
 
-    # This is kinda unreadable, sorry
-    new_dfm <- new("dfmSparse", Matrix::rbind2(
-        Matrix::cbind2(
-            Matrix::cbind2(
+    xcols <- Matrix::cbind2(
                 x[, common_names],
                 x[, only_x_names]
-            ),
-            Matrix::sparseMatrix(i = NULL, j = NULL, dims = c(ndoc(x), 
+    )
+    empty_ycols <- Matrix::sparseMatrix(i = NULL, j = NULL, dims = c(ndoc(x), 
                 length(only_y_names)), dimnames = list(NULL, only_y_names))
-        ),
-        Matrix::cbind2(
-            Matrix::cbind2(
-                y[, common_names],
-                Matrix::sparseMatrix(i = NULL, j = NULL, dims = c(ndoc(y), 
+
+    empty_xcols <- Matrix::sparseMatrix(i = NULL, j = NULL, dims = c(ndoc(y), 
                     length(only_x_names)), dimnames = list(NULL, only_x_names))
-            ),
-                y[, only_y_names]
+
+    y_with_xcols <- Matrix::cbind2(
+                y[, common_names],
+                empty_xcols
             )
-    )
-    )
+
+    # This is kinda unreadable, sorry
+    new_dfm <- new("dfmSparse", Matrix::rbind2(
+        Matrix::cbind2( xcols, empty_ycols),
+        Matrix::cbind2( y_with_xcols, y[, only_y_names])
+    ))
+
     new_dfm[, order(features(new_dfm))]
 }
+
 rbind2.dfm.old <- function(x, y) {
     x.names <- features(x)
     y.names <- features(y)

--- a/tests/testthat/testDfm.R
+++ b/tests/testthat/testDfm.R
@@ -118,6 +118,8 @@ test_that("test rbind.dfm with the same columns", {
 
 })
 
+# TODO: Add function for testing the equality of dfms
+
 test_that("test rbind.dfm with different columns", {
     dfm1 <- dfm('What does the fox?')
     dfm2 <- dfm('fox say')
@@ -128,8 +130,11 @@ test_that("test rbind.dfm with different columns", {
     rownames(foxdfm) <-  c('text1', 'text2')
     foxdfm <- as.matrix(foxdfm)
 
+    testdfm <- rbind(dfm1, dfm2)
+
     expect_true(
-        all(rbind(dfm1, dfm2) == foxdfm)
+        ##  Order of the result is not guaranteed
+        all(testdfm[,order(colnames(testdfm))] == foxdfm[,order(colnames(foxdfm))])
     )
 
     expect_that(
@@ -151,8 +156,9 @@ test_that("test rbind.dfm with different columns, three args and repeated words"
     rownames(foxdfm) <-  c('text1', 'text1', 'text1')
     foxdfm <- as.matrix(foxdfm)
 
+    testdfm <- rbind(dfm1, dfm2, dfm3)
     expect_true(
-        all(rbind(dfm1, dfm2, dfm3) == foxdfm)
+        all(testdfm[,order(colnames(testdfm))] == foxdfm[,order(colnames(foxdfm))])
     )
 
     expect_that(
@@ -166,7 +172,7 @@ test_that("test rbind.dfm with a single argument returns the same dfm", {
     fox <-'What does the fox say?'
     expect_true(
         all(
-            rbind(dfm(fox)) == dfm(fox)[, order(features(dfm(fox)))]
+            rbind(dfm(fox)) == dfm(fox)
         )
     )
     expect_that(
@@ -184,15 +190,6 @@ test_that("test that rbind.dfm with a single argument prints a warning", {
 
 })
 
-test_that("test that rbind.dfm with a single argument sorts features", {
-    fox <-'What does the fox say?'
-    xof <-'say fox the does What??'
-    expect_true(
-        all(
-            rbind(dfm(xof)) == dfm(fox)[, order(features(dfm(fox)))]
-        )
-    )
-})
 
 
 test_that("test rbind.dfm with the same features, but in a different order", {
@@ -209,5 +206,6 @@ test_that("test rbind.dfm with the same features, but in a different order", {
     expect_true(
         all(rbind(dfm1, dfm1) == foxdfm)
     )
+
 
 })

--- a/tests/testthat/testDfm.R
+++ b/tests/testthat/testDfm.R
@@ -144,3 +144,15 @@ test_that("test rbind.dfm with different columns, three args and repeated words"
 
 })
 
+test_that("test rbind.dfm with a single argument", {
+    fox <-'What does the fox say?'
+    expect_equal(
+        rbind(dfm(fox)),
+        dfm(fox)
+        )
+
+    expect_that(
+        rbind(dfm(fox)),
+        gives_warning('rbind.dfm called on single dfm')
+        )
+})

--- a/tests/testthat/testDfm.R
+++ b/tests/testthat/testDfm.R
@@ -156,3 +156,20 @@ test_that("test rbind.dfm with a single argument", {
         gives_warning('rbind.dfm called on single dfm')
         )
 })
+
+test_that("test rbind.dfm with the same features, but in a different order", {
+
+    fox <-'What does the fox say?'
+    xof <-'say fox the does What??'
+    foxdfm <- rep(1, 20)
+    dim(foxdfm) <- c(4,5)
+    colnames(foxdfm) <- c('does', 'fox', 'say', 'the', 'what')
+    rownames(foxdfm) <-  rep(c('text1', 'text2'), 2)
+
+    dfm1 <- dfm(c(fox, xof))
+
+    expect_true(
+        all(rbind(dfm1, dfm1) == foxdfm)
+    )
+
+})

--- a/tests/testthat/testDfm.R
+++ b/tests/testthat/testDfm.R
@@ -111,6 +111,10 @@ test_that("test rbind.dfm with the same columns", {
     expect_true(
         all(rbind(dfm1, dfm1) == foxdfm)
     )
+    expect_that(
+        rbind(dfm1, dfm1),
+        is_a('dfmSparse')
+    )
 
 })
 
@@ -126,6 +130,11 @@ test_that("test rbind.dfm with different columns", {
 
     expect_true(
         all(rbind(dfm1, dfm2) == foxdfm)
+    )
+
+    expect_that(
+        rbind(dfm1, dfm2),
+        is_a('dfmSparse')
     )
 
 })
@@ -146,6 +155,11 @@ test_that("test rbind.dfm with different columns, three args and repeated words"
         all(rbind(dfm1, dfm2, dfm3) == foxdfm)
     )
 
+    expect_that(
+        rbind(dfm1, dfm2, dfm3),
+        is_a('dfmSparse')
+    )
+
 })
 
 test_that("test rbind.dfm with a single argument returns the same dfm", {
@@ -154,6 +168,10 @@ test_that("test rbind.dfm with a single argument returns the same dfm", {
         all(
             rbind(dfm(fox)) == dfm(fox)[, order(features(dfm(fox)))]
         )
+    )
+    expect_that(
+        rbind(dfm(fox)),
+        is_a('dfmSparse')
     )
 })
 

--- a/tests/testthat/testDfm.R
+++ b/tests/testthat/testDfm.R
@@ -95,6 +95,9 @@ test_that("test c.corpus",
     )
 )
 
+## rbind.dfm
+## TODO: Test classes returned
+
 test_that("test rbind.dfm with the same columns", {
 
     fox <-'What does the fox say?'
@@ -112,18 +115,19 @@ test_that("test rbind.dfm with the same columns", {
 })
 
 test_that("test rbind.dfm with different columns", {
-    dfm1 <- dfm('What does the?')
+    dfm1 <- dfm('What does the fox?')
     dfm2 <- dfm('fox say')
 
-    foxdfm <- c(1, 0, 0, 1, 0, 1, 1, 0, 1, 0)
+    foxdfm <- c(1, 0, 1, 1, 0, 1, 1, 0, 1, 0)
     dim(foxdfm) <- c(2,5)
     colnames(foxdfm) <- c('does', 'fox', 'say', 'the', 'what')
     rownames(foxdfm) <-  c('text1', 'text2')
     foxdfm <- as.matrix(foxdfm)
 
     expect_true(
-        all(rbind(dfm1, dfm2) ==foxdfm)
+        all(rbind(dfm1, dfm2) == foxdfm)
     )
+
 })
 
 test_that("test rbind.dfm with different columns, three args and repeated words", {
@@ -146,10 +150,11 @@ test_that("test rbind.dfm with different columns, three args and repeated words"
 
 test_that("test rbind.dfm with a single argument returns the same dfm", {
     fox <-'What does the fox say?'
-    expect_equal(
-        as.data.frame(rbind(dfm(fox))),
-        as.data.frame(dfm(fox))[, order(features(dfm(fox)))]
+    expect_true(
+        all(
+            rbind(dfm(fox)) == dfm(fox)[, order(features(dfm(fox)))]
         )
+    )
 })
 
 test_that("test that rbind.dfm with a single argument prints a warning", {
@@ -164,13 +169,13 @@ test_that("test that rbind.dfm with a single argument prints a warning", {
 test_that("test that rbind.dfm with a single argument sorts features", {
     fox <-'What does the fox say?'
     xof <-'say fox the does What??'
-
-    expect_equivalent(
-        as.data.frame(rbind(dfm(xof))),
-        as.data.frame(dfm(fox))[, order(features(dfm(fox)))]
+    expect_true(
+        all(
+            rbind(dfm(xof)) == dfm(fox)[, order(features(dfm(fox)))]
+        )
     )
-
 })
+
 
 test_that("test rbind.dfm with the same features, but in a different order", {
 

--- a/tests/testthat/testDfm.R
+++ b/tests/testthat/testDfm.R
@@ -94,3 +94,53 @@ test_that("test c.corpus",
         equals(matrix(rep(c(1, 1, 0), 5), nrow=15, ncol=1))
     )
 )
+
+test_that("test rbind.dfm with the same columns", {
+
+    fox <-'What does the fox say?'
+    foxdfm <- rep(1, 20)
+    dim(foxdfm) <- c(4,5)
+    colnames(foxdfm) <- c('does', 'fox', 'say', 'the', 'what')
+    rownames(foxdfm) <-  rep(c('text1', 'text2'), 2)
+
+    dfm1 <- dfm(c(fox, fox))
+
+    expect_true(
+        all(rbind(dfm1, dfm1) == foxdfm)
+    )
+
+})
+
+test_that("test rbind.dfm with different columns", {
+    dfm1 <- dfm('What does the?')
+    dfm2 <- dfm('fox say')
+
+    foxdfm <- c(1, 0, 0, 1, 0, 1, 1, 0, 1, 0)
+    dim(foxdfm) <- c(2,5)
+    colnames(foxdfm) <- c('does', 'fox', 'say', 'the', 'what')
+    rownames(foxdfm) <-  c('text1', 'text2')
+    foxdfm <- as.matrix(foxdfm)
+
+    expect_true(
+        all(rbind(dfm1, dfm2) ==foxdfm)
+    )
+})
+
+test_that("test rbind.dfm with different columns, three args and repeated words", {
+
+    dfm1 <- dfm('What does the?')
+    dfm2 <- dfm('fox say fox')
+    dfm3 <- dfm('The quick brown fox')
+
+    foxdfm <- c(0, 0, 1, 1, 0, 0, 0, 2, 1, 0, 0, 1, 0, 1, 0, 1, 0, 1, 1, 0, 0)
+    dim(foxdfm) <- c(3,7)
+    colnames(foxdfm) <- c('brown', 'does', 'fox', 'quick', 'say', 'the', 'what')
+    rownames(foxdfm) <-  c('text1', 'text1', 'text1')
+    foxdfm <- as.matrix(foxdfm)
+
+    expect_true(
+        all(rbind(dfm1, dfm2, dfm3) == foxdfm)
+    )
+
+})
+

--- a/tests/testthat/testDfm.R
+++ b/tests/testthat/testDfm.R
@@ -144,17 +144,32 @@ test_that("test rbind.dfm with different columns, three args and repeated words"
 
 })
 
-test_that("test rbind.dfm with a single argument", {
+test_that("test rbind.dfm with a single argument returns the same dfm", {
     fox <-'What does the fox say?'
     expect_equal(
-        rbind(dfm(fox)),
-        dfm(fox)
+        as.data.frame(rbind(dfm(fox))),
+        as.data.frame(dfm(fox))[, order(features(dfm(fox)))]
         )
+})
 
+test_that("test that rbind.dfm with a single argument prints a warning", {
+    fox <-'What does the fox say?'
     expect_that(
         rbind(dfm(fox)),
         gives_warning('rbind.dfm called on single dfm')
         )
+
+})
+
+test_that("test that rbind.dfm with a single argument sorts features", {
+    fox <-'What does the fox say?'
+    xof <-'say fox the does What??'
+
+    expect_equivalent(
+        as.data.frame(rbind(dfm(xof))),
+        as.data.frame(dfm(fox))[, order(features(dfm(fox)))]
+    )
+
 })
 
 test_that("test rbind.dfm with the same features, but in a different order", {


### PR DESCRIPTION
In two ways:
- less intermediate shuffling of columns
- directly call Matrix::rbind2 if the columns are identical

This has the behaviour change of no longer returning an ordered list of feature-columns (which will require a version bump, documentation updates, etc.).

Incidentally, this also fixes a bug when rbind is called with a single dfm argument.

Fixes #173 