### PR TITLE
Fix bug in corpus text_field

### DIFF
--- a/R/corpus.R
+++ b/R/corpus.R
@@ -18,7 +18,7 @@
 #' @param docnames Names to be assigned to the texts, defaults to the names of 
 #'   the character vector (if any), otherwise assigns "text1", "text2", etc.
 #' @param docvars A data frame of attributes that is associated with each text.
-#' @param text_field the character name or integer index of the source \code{data.frame}
+#' @param text_field the character name or numeric integer index of the source \code{data.frame}
 #'   indicating the variable to be read in as text, which must be a character vector.
 #'   All other variables in the data.frame will be imported as docvars.  This argument 
 #'   is only used for \code{data.frame} objects (including those created by \pkg{readtext}).
@@ -214,6 +214,11 @@ corpus.data.frame <- function(x, docnames = NULL, docvars = NULL, text_field = "
         if (length(text_fieldi)==0)
             stop("column name ", text_field, " not found.")
         text_field <- text_fieldi
+    } 
+    else if (is.numeric(text_field)) {
+        text_fieldi <- text_field
+        if (length(text_fieldi != 1)
+            stop("Only one text_field may be specified.")
     }
     if (!is.character(x[, text_fieldi]))
         stop("text_field must refer to a character mode column")

--- a/R/corpus.R
+++ b/R/corpus.R
@@ -217,7 +217,7 @@ corpus.data.frame <- function(x, docnames = NULL, docvars = NULL, text_field = "
     } 
     else if (is.numeric(text_field)) {
         text_fieldi <- text_field
-        if (length(text_fieldi != 1))
+        if (length(text_fieldi) != 1)
             stop("Only one text_field may be specified.")
     }
     if (!is.character(x[, text_fieldi]))

--- a/R/corpus.R
+++ b/R/corpus.R
@@ -217,7 +217,7 @@ corpus.data.frame <- function(x, docnames = NULL, docvars = NULL, text_field = "
     } 
     else if (is.numeric(text_field)) {
         text_fieldi <- text_field
-        if (length(text_fieldi != 1)
+        if (length(text_fieldi != 1))
             stop("Only one text_field may be specified.")
     }
     if (!is.character(x[, text_fieldi]))


### PR DESCRIPTION
The corpus function mentions that an integer can be supplied to the `text_field` argument in `corpus`. However, this returns an error where `text_fieldi` is not found. 

The cause of this error is that `text_fieldi` is not created when the `text_field` value is not a character. 

This pull request fixes this bug, checks that if  `text_field` is present that it is length = 1.  