### PR TITLE
Error checking and argument handling for dictionary construction

### DIFF
--- a/R/convert.R
+++ b/R/convert.R
@@ -38,10 +38,6 @@
 #' # austin's wfm format
 #' identical(dim(quantdfm), dim(convert(quantdfm, to = "austin")))
 #' 
-#' # tm's DocumentTermMatrix format
-#' tmdfm <- convert(quantdfm, to = "tm")
-#' str(tmdfm)
-#' 
 #' # stm package format
 #' stmdfm <- convert(quantdfm, to = "stm")
 #' str(stmdfm)
@@ -51,12 +47,18 @@
 #' stmdfm2 <- convert(quantdfm2, to = "stm", docvars = docvars(mycorpus))
 #' str(stmdfm2)
 #'  
+#' \dontrun{
+#' #' # tm's DocumentTermMatrix format
+#' tmdfm <- convert(quantdfm, to = "tm")
+#' str(tmdfm)
+#' 
 #' # topicmodels package format
 #' str(convert(quantdfm, to = "topicmodels"))
 #' 
 #' # lda package format
 #' ldadfm <- convert(quantdfm, to = "lda")
 #' str(ldadfm)
+#' }
 convert <- function(x, to = c("lda", "tm", "stm", "austin", "topicmodels", "lsa",
                          "matrix", "data.frame"), docvars = NULL, ...) {
     UseMethod("convert")
@@ -169,8 +171,10 @@ dfm2tmformat <- function(x, weighting = tm::weightTf) {
 #'   weighting functions from the \pkg{tm} package, see 
 #'   \code{\link[tm]{TermDocumentMatrix}}.
 #' @examples
+#' \dontrun{
 #' # shortcut conversion to tm package's DocumentTermMatrix format
 #' identical(as.DocumentTermMatrix(quantdfm), convert(quantdfm, to = "tm"))
+#' }
 #' 
 as.DocumentTermMatrix <- function(x, ...) {
     if (!is.dfm(x))
@@ -186,8 +190,10 @@ as.DocumentTermMatrix <- function(x, ...) {
 #'   \code{\link[lda]{lda.collapsed.gibbs.sampler}}).
 #' @export
 #' @examples
+#' \dontrun{
 #' # shortcut conversion to lda package list format
 #' identical(dfm2ldaformat(quantdfm), convert(quantdfm, to = "lda")) 
+#' }
 #' 
 dfm2ldaformat <- function(x) {
     if (!is.dfm(x))
@@ -224,8 +230,10 @@ dtm2ldaformat <- function (x, omit_empty = TRUE) {
 #' \pkg{topicmodels} package.
 #' @examples 
 #' # shortcut conversion to topicmodels package format
+#' \dontrun{
 #' identical(quantedaformat2dtm(quantdfm), 
 #'           convert(quantdfm, to = "topicmodels")) 
+#' }
 #' 
 quantedaformat2dtm <- function(x) {
     if (!is.dfm(x))

--- a/R/dictionaries.R
+++ b/R/dictionaries.R
@@ -15,6 +15,23 @@ setClass("dictionary", contains = c("list"),
          slots = c(concatenator = "character", format = "charNULL", file = "charNULL"),
          prototype = prototype(concatenator = " ", format = NULL, file = NULL))
 
+setValidity("dictionary", function(object) {
+    # does every element have a name? simply needs to pass
+    dummy <- dictionary_flatten(object)
+    # is every element a character?
+    if (all(charvals <- sapply(object, is.character))) {
+        return(TRUE)
+    } else {
+        retmsg <-character()
+        for (i in which(!charvals)) {
+            retmsg <- paste0(retmsg, "\n  non-character entries found: ",
+                             names(object)[i], " : ",
+                             paste(object[[i]], collapse = " "))
+        }
+        return(retmsg)
+    }
+})
+
 #' print a dictionary object
 #' 
 #' Print/show method for dictionary objects.
@@ -41,8 +58,10 @@ setMethod("show", "dictionary",
 #' LIWC format works with 
 #' all currently available dictionary files supplied as part of the LIWC 2001, 
 #' 2007, and 2015 software (see References).
-#' @param x a list of character vector dictionary entries, including regular 
-#'   expressions (see examples)
+#' @param ... a named list of character vector dictionary entries, including \link{valuetype} pattern
+#'  matches, and including multi-word expressions separated by \code{concatenator}.  The argument 
+#'  may be an explicit list or named set of elements that can be turned into a list.  See examples.
+#'  This argument may be omitted if the dictionary is read from \code{file}.
 #' @param file file identifier for a foreign dictionary
 #' @param format character identifier for the format of the foreign dictionary. 
 #'   If not supplied, the format is guessed from the dictionary file's
@@ -82,6 +101,11 @@ setMethod("show", "dictionary",
 #'                           country = "america"))
 #' head(dfm(mycorpus, dictionary = mydict))
 #' 
+#' # also works
+#' mydict2 <- dictionary(christmas = c("Christmas", "Santa", "holiday"),
+#'                       opposition = c("Opposition", "reject", "notincorpus"))
+#' dfm(mycorpus, dictionary = mydict2)
+#' 
 #' \dontrun{
 #' # import the Laver-Garry dictionary from http://bit.ly/1FH2nvf
 #' lgdict <- dictionary(file = "http://www.kenbenoit.net/courses/essex2014qta/LaverGarry.cat",
@@ -94,19 +118,22 @@ setMethod("show", "dictionary",
 #' @importFrom stats setNames
 #' @importFrom tools file_ext
 #' @export
-dictionary <- function(x = NULL, file = NULL, format = NULL, 
+dictionary <- function(..., file = NULL, format = NULL, 
                        concatenator = " ", 
                        toLower = TRUE, encoding = "") {
+  # these allow implicit list construction through ...
+  x <- list(...)
+  if (length(x)==1) 
+      x <- as.list(x[[1]])
   if (!is.null(x) & !is.list(x))
     stop("Dictionaries must be named lists or lists of named lists.")
-  if (any(missingLabels <- which(names(x) == ""))) 
-    stop("missing key name for list element", 
-         ifelse(length(missingLabels)>1, "s ", " "),
-         missingLabels, "\n") 
-  x <- dictionary_flatten(x)
-  if (!is.null(x) & !is.list(x))
-    stop("Dictionaries must be named lists or lists of named lists.")
-  
+  # if (any(missingLabels <- which(names(x) == ""))) 
+  #   stop("missing key name for list element", 
+  #        ifelse(length(missingLabels)>1, "s ", " "),
+  #        missingLabels, "\n") 
+  # if (!is.null(x) & !is.list(x))
+  #   stop("Dictionaries must be named lists or lists of named lists.")
+
   dict_format_mapping <- c(cat="wordstat", dic="LIWC", ykd="yoshikoder", lcd="yoshikoder", lc3="lexicoder")
   if (!is.null(file)) {
 
@@ -135,6 +162,7 @@ dictionary <- function(x = NULL, file = NULL, format = NULL,
 
   }
   
+  x <- dictionary_flatten(x)
   new("dictionary", x, format = format, file = file, concatenator = concatenator)
 }
 
@@ -373,8 +401,15 @@ readYKdict <- function(path){
 #                               level1c1b = list(level1c1b1 = c("lowestalone"))))
 #  dictionary_flatten(hdict)
 dictionary_flatten <- function(elms, parent = '', dict = list()) {
-    if (any(names(elms) == ""))
-        stop("missing name for a nested key")
+    # are all elements unnamed?
+    if (is.null(names(elms))) {
+        stop("dictionary elements must be named")
+    }
+    # are any elements unnamed?
+    if (any(names(elms) == "")) {
+        unnamed <- elms[which(names(elms) == "")]
+        stop("unnamed dictionary entry: ", unnamed)
+    }
     for (self in names(elms)) {
         elm <- elms[[self]]
         if (parent != '') {
@@ -406,25 +441,25 @@ dictionary_flatten <- function(elms, parent = '', dict = list()) {
 # @author Adam Obeng
 # @export
 readLexicoderDict <- function(path, toLower=TRUE) {
-  current_key <- NULL
-  current_terms <- c()
-  dict <- list() 
-  #  Lexicoder 3.0 files are always UTF-8
-  for (l in readLines(con <- file(path, encoding = 'utf-8'))) {
-    if (toLower) l <- tolower(l)
-    if (substr(l, 1, 1) == '+') {
-      if (length(current_terms) > 0) {
-        dict[[current_key]] <- current_terms
-      }
-      current_key <- substr(l, 2, nchar(l))
-      current_terms <- c()
+    current_key <- NULL
+    current_terms <- c()
+    dict <- list() 
+    #  Lexicoder 3.0 files are always UTF-8
+    for (l in readLines(con <- file(path, encoding = 'utf-8'))) {
+        if (toLower) l <- tolower(l)
+        if (substr(l, 1, 1) == '+') {
+            if (length(current_terms) > 0) {
+                dict[[current_key]] <- current_terms
+            }
+            current_key <- substr(l, 2, nchar(l))
+            current_terms <- c()
+        }
+        else {
+            current_terms <- c(current_terms, l)
+        }
     }
-    else {
-      current_terms <- c(current_terms, l)
-    }
-  }
-  dict[[current_key]] <- current_terms
-  return(dict)
+    dict[[current_key]] <- current_terms
+    return(dict)
 }
 
 #' check if an object is a dictionary

--- a/man/convert-wrappers.Rd
+++ b/man/convert-wrappers.Rd
@@ -70,15 +70,21 @@ quantdfm <- dfm(mycorpus, verbose = FALSE)
 # shortcut conversion to austin package's wfm format
 identical(as.wfm(quantdfm), convert(quantdfm, to = "austin"))
 
+\dontrun{
 # shortcut conversion to tm package's DocumentTermMatrix format
 identical(as.DocumentTermMatrix(quantdfm), convert(quantdfm, to = "tm"))
+}
 
+\dontrun{
 # shortcut conversion to lda package list format
 identical(dfm2ldaformat(quantdfm), convert(quantdfm, to = "lda")) 
+}
 
 # shortcut conversion to topicmodels package format
+\dontrun{
 identical(quantedaformat2dtm(quantdfm), 
           convert(quantdfm, to = "topicmodels")) 
+}
 
 }
 \keyword{internal}

--- a/man/convert.Rd
+++ b/man/convert.Rd
@@ -53,10 +53,6 @@ quantdfm <- dfm(mycorpus, verbose = FALSE)
 # austin's wfm format
 identical(dim(quantdfm), dim(convert(quantdfm, to = "austin")))
 
-# tm's DocumentTermMatrix format
-tmdfm <- convert(quantdfm, to = "tm")
-str(tmdfm)
-
 # stm package format
 stmdfm <- convert(quantdfm, to = "stm")
 str(stmdfm)
@@ -66,11 +62,17 @@ rowSums(quantdfm2)
 stmdfm2 <- convert(quantdfm2, to = "stm", docvars = docvars(mycorpus))
 str(stmdfm2)
  
+\dontrun{
+#' # tm's DocumentTermMatrix format
+tmdfm <- convert(quantdfm, to = "tm")
+str(tmdfm)
+
 # topicmodels package format
 str(convert(quantdfm, to = "topicmodels"))
 
 # lda package format
 ldadfm <- convert(quantdfm, to = "lda")
 str(ldadfm)
+}
 }
 

--- a/man/dictionary.Rd
+++ b/man/dictionary.Rd
@@ -4,12 +4,14 @@
 \alias{dictionary}
 \title{create a dictionary}
 \usage{
-dictionary(x = NULL, file = NULL, format = NULL, concatenator = " ",
+dictionary(..., file = NULL, format = NULL, concatenator = " ",
   toLower = TRUE, encoding = "")
 }
 \arguments{
-\item{x}{a list of character vector dictionary entries, including regular 
-expressions (see examples)}
+\item{...}{a named list of character vector dictionary entries, including \link{valuetype} pattern
+matches, and including multi-word expressions separated by \code{concatenator}.  The argument 
+may be an explicit list or named set of elements that can be turned into a list.  See examples.
+This argument may be omitted if the dictionary is read from \code{file}.}
 
 \item{file}{file identifier for a foreign dictionary}
 
@@ -53,6 +55,11 @@ mydict <- dictionary(list(christmas = c("Christmas", "Santa", "holiday"),
                           taxregex = "tax*",
                           country = "america"))
 head(dfm(mycorpus, dictionary = mydict))
+
+# also works
+mydict2 <- dictionary(christmas = c("Christmas", "Santa", "holiday"),
+                      opposition = c("Opposition", "reject", "notincorpus"))
+dfm(mycorpus, dictionary = mydict2)
 
 \dontrun{
 # import the Laver-Garry dictionary from http://bit.ly/1FH2nvf

--- a/tests/data/dictionaries/mary.dic
+++ b/tests/data/dictionaries/mary.dic
@@ -1,6 +1,6 @@
 %
-01	A category
-02	Another category
+01	A_CATEGORY
+02	ANOTHER_CATEGORY
 %
 
 more	01

--- a/tests/data/dictionaries/mary.lc3
+++ b/tests/data/dictionaries/mary.lc3
@@ -1,7 +1,7 @@
-+A category
++A CATEGORY
 more
 lamb
 little
-+Another category
++ANOTHER CATEGORY
 had
 mary

--- a/tests/testthat/test-convert.R
+++ b/tests/testthat/test-convert.R
@@ -7,6 +7,7 @@ d <- dfm(mytexts, removePunct = TRUE)
 
 test_that("test STM package converter", {
     skip_if_not_installed("stm")
+    skip_if_not_installed("tm")
     
     dSTM <- convert(d, to = "stm")
     tP <- stm::textProcessor(mytexts, removestopwords = FALSE, 
@@ -30,10 +31,12 @@ test_that("test tm package converter", {
 })
 
 test_that("test lda package converter", {
+    skip_if_not_installed("tm")
     expect_identical(convert(d, to = "topicmodels"), quantedaformat2dtm(d))
 })
 
 test_that("test topicmodels package converter", {
+    skip_if_not_installed("tm")
     expect_identical(convert(d, to = "lda"), dfm2ldaformat(d))
 })
 

--- a/tests/testthat/test-dictionaries.R
+++ b/tests/testthat/test-dictionaries.R
@@ -1,0 +1,51 @@
+context("dictionary construction")
+
+test_that("dictionary constructors fail if all elements unnamed: explicit", {
+    expect_error(dictionary(list(c("a, b"), "C")),
+                 "dictionary elements must be named")
+    expect_error(dictionary(list(first =  c("a, b"), "C")),
+                 "unnamed dictionary entry: C")
+})
+
+test_that("dictionary constructors fail if all elements unnamed: implicit", {
+    expect_error(dictionary(c("a, b"), "C"),
+                 "dictionary elements must be named")
+    expect_error(dictionary(first =  c("a, b"), "C"),
+                 "unnamed dictionary entry: C")
+})
+
+test_that("dictionary constructors fail if a value is numeric", {
+    expect_error(dictionary(list(first =  c("a, b"), second = 2)),
+                 "non-character entries found: second : 2")
+})
+
+test_that("dictionary constructor works on list explicitly or implicitly", {
+    expect_equal(dictionary(list(first =  c("a, b"), second = "c")),
+                 dictionary(first =  c("a, b"), second = "c"))
+})
+
+marydict <- dictionary("A CATEGORY" = c("more", "lamb", "little"),
+                       "ANOTHER CATEGORY" = c("had", "mary"))
+
+test_that("dictionary constructor works with wordstat format", {
+    expect_equivalent(dictionary(file = "../data/dictionaries/mary.cat"),
+                      marydict)
+})
+
+test_that("dictionary constructor works with Yoshikoder format", {
+    expect_equivalent(dictionary(file = "../data/dictionaries/mary.ykd"),
+                      marydict)
+})
+
+test_that("dictionary constructor works with LIWC format", {
+    expect_equivalent(dictionary(file = "../data/dictionaries/mary.dic"),
+                      dictionary("A_CATEGORY" = c("lamb", "little", "more"),
+                                 "ANOTHER_CATEGORY" = c("had", "mary")))
+})
+
+test_that("dictionary constructor works with Lexicoder format", {
+    expect_equivalent(dictionary(file = "../data/dictionaries/mary.lcd", toLower = FALSE),
+                      dictionary("A category" = c("more", "lamb", "little"),
+                                 "Another category" = c("had", "mary")))
+})
+


### PR DESCRIPTION
Makes it possible to construct a list through dictionary(), without wrapping it in a list().

Adds a validator to the S4 class for dictionary, to ensure that all values are character, and better tests that all keys are supplied (as list names).

Adds constructor tests for dictionary for above conditions, and for file formats.

Also removes the **tm** package from `Imports` by conditioning the examples and the `testthat` tests.

Closes #407