### PR TITLE
Issue 463

### DIFF
--- a/src/quanteda.h
+++ b/src/quanteda.h
@@ -72,7 +72,9 @@ namespace quanteda{
 namespace ngrams {
     typedef std::vector<unsigned int> Ngram;
     typedef std::vector<Ngram> Ngrams;
-
+    typedef std::string Type;
+    typedef std::vector<Type> Types;
+    
     struct hash_ngram {
             std::size_t operator() (const Ngram &vec) const {
             unsigned int seed = 0;

--- a/src/tokens_ngrams_mt.cpp
+++ b/src/tokens_ngrams_mt.cpp
@@ -92,9 +92,9 @@ struct skipgram_mt : public Worker{
     const std::vector<unsigned int> &skips;
     MapNgrams &map_ngram;
     
-    skipgram_mt(Texts &input_, Texts &output_, std::vector<unsigned int> &ns_, std::vector<unsigned int> &skips_, 
-                MapNgrams &map_ngram_):
-        input(input_), output(output_), ns(ns_), skips(skips_), map_ngram(map_ngram_){}
+    skipgram_mt(Texts &input_, Texts &output_, std::vector<unsigned int> &ns_, 
+                std::vector<unsigned int> &skips_, MapNgrams &map_ngram_):
+                input(input_), output(output_), ns(ns_), skips(skips_), map_ngram(map_ngram_){}
     
     void operator()(std::size_t begin, std::size_t end){
         //Rcout << "Range " << begin << " " << end << "\n";
@@ -129,8 +129,10 @@ struct type_mt : public Worker{
     const std::string &delim;
     const Types &types;
     
-    type_mt(Types &types_ngram_, VecNgrams &keys_ngram_, MapNgrams &map_ngram_, std::string &delim_, Types &types_):
-        types_ngram(types_ngram_), keys_ngram(keys_ngram_), map_ngram(map_ngram_), delim(delim_), types(types_) {}
+    type_mt(Types &types_ngram_, VecNgrams &keys_ngram_, MapNgrams &map_ngram_, 
+            std::string &delim_, Types &types_):
+            types_ngram(types_ngram_), keys_ngram(keys_ngram_), map_ngram(map_ngram_), 
+            delim(delim_), types(types_) {}
     
     void operator()(std::size_t begin, std::size_t end){
         //Rcout << "Range " << begin << " " << end << "\n";

--- a/tests/benchmarks/benchmark_tokens/ngrams.R
+++ b/tests/benchmarks/benchmark_tokens/ngrams.R
@@ -17,7 +17,7 @@ microbenchmark::microbenchmark(
 microbenchmark::microbenchmark(
     tokenizers = as.tokens(tokenize_skip_ngrams(txt, n = 2, k = 1)),
     quanteda = quanteda::tokens_ngrams(as.tokens(tokenize_words(txt)), n = 2, skip = 1),
-    unit='relative', times = 1
+    unit='relative', times = 10
 )
 
 tok <- tokens(txt, removeSymbols = TRUE, removeNumbers = TRUE)

--- a/tests/benchmarks/benchmark_tokens/ngrams.R
+++ b/tests/benchmarks/benchmark_tokens/ngrams.R
@@ -10,13 +10,13 @@ txt <- texts(SOTUCorpus)
 
 microbenchmark::microbenchmark(
     tokenizers = as.tokens(tokenize_ngrams(txt, n = 2)),
-    quanteda_t1 = quanteda::tokens_ngrams(as.tokens(tokenize_words(txt)), n = 2),
-    unit='relative', times = 1
+    quanteda = quanteda::tokens_ngrams(as.tokens(tokenize_words(txt)), n = 2),
+    unit='relative', times = 10
 )
 
 microbenchmark::microbenchmark(
     tokenizers = as.tokens(tokenize_skip_ngrams(txt, n = 2, k = 1)),
-    quanteda_t1 = quanteda::ngrams(as.tokens(tokenize_words(txt)), n = 2, skip = 1),
+    quanteda = quanteda::tokens_ngrams(as.tokens(tokenize_words(txt)), n = 2, skip = 1),
     unit='relative', times = 1
 )
 

--- a/tests/benchmarks/benchmark_tokens/ngrams.R
+++ b/tests/benchmarks/benchmark_tokens/ngrams.R
@@ -1,35 +1,34 @@
-library(profvis) # for profiling
-library(tokenizers)
 library(quanteda)
 
-txt <- readLines('~/Documents/Brexit/Analysis/all_bbc_2015.txt') # 80MB
-txt <- readLines('~/Documents/LSS/Data/Ukracine crisis/ua_3agency.txt') # 660MB
-
-data(SOTUCorpus, package = "quantedaData")
-txt <- texts(SOTUCorpus)
+load("/home/kohei/Documents/Brexit/Analysis/data_corpus_guardian.RData")
+docvars(data_corpus_guardian, 'year') <- format(docvars(data_corpus_guardian, 'date'), '%Y')
+txts <- texts(corpus_subset(data_corpus_guardian, year == 2015))
 
 microbenchmark::microbenchmark(
-    tokenizers = as.tokens(tokenize_ngrams(txt, n = 2)),
-    quanteda = quanteda::tokens_ngrams(as.tokens(tokenize_words(txt)), n = 2),
+    tokenizers = tokenizers::tokenize_ngrams(txts, n = 2),
+    quanteda = tokens_ngrams(as.tokens(tokenize_words(txts)), n = 2),
     unit='relative', times = 10
 )
 
+object.size(tokenizers::tokenize_ngrams(txts, n = 2), 'MB')
+object.size(tokens_ngrams(as.tokens(tokenize_words(txts)), n = 2), 'MB')
+
 microbenchmark::microbenchmark(
-    tokenizers = as.tokens(tokenize_skip_ngrams(txt, n = 2, k = 1)),
-    quanteda = quanteda::tokens_ngrams(as.tokens(tokenize_words(txt)), n = 2, skip = 1),
+    tokenizers = tokenizers::tokenize_skip_ngrams(txts, n = 2, k = 1),
+    quanteda = tokens_ngrams(as.tokens(tokenize_words(txts)), n = 2, skip = 1),
     unit='relative', times = 10
 )
 
-tok <- tokens(txt, removeSymbols = TRUE, removeNumbers = TRUE)
+toks <- tokens(txts, removeSymbols = TRUE, removeNumbers = TRUE)
 
 microbenchmark::microbenchmark(
-    tokens_ngrams(tok, n=2),
-    tokens_ngrams(tok, n=3),
-    tokens_ngrams(tok, n=4),
-    tokens_ngrams(tok, n=5),
+    tokens_ngrams(toks, n=2),
+    tokens_ngrams(toks, n=3),
+    tokens_ngrams(toks, n=4),
+    tokens_ngrams(toks, n=5),
     times=1
 )
 
-profvis::profvis(tokens_ngrams(tok, 2))
-profvis::profvis(quanteda::tokens_ngrams(tokens(txt), n = 2))
+profvis::profvis(tokens_ngrams(toks, 2))
+profvis::profvis(quanteda::tokens_ngrams(tokens(txts), n = 2))
 


### PR DESCRIPTION
With this performance optimization, tokens_ngrams became as fast as the ngram generator in tokenizers, while keeping the output object size 75% smaller.