### PR TITLE
Fixes #467 dfm_compress bug

### DIFF
--- a/R/dfm_compress.R
+++ b/R/dfm_compress.R
@@ -44,6 +44,7 @@ dfm_compress <- function(x, margin = c("both", "documents", "features")) {
     new_j <- as(x, "dgTMatrix")@j + 1
     
     allZeroFeatures <- match(names(which(colSums(x)==0)), uniquefnames)
+    allZeroDocs <- match(names(which(rowSums(x)==0)), uniquednames)
     
     # combine documents
     if (margin %in% c("both", "documents") & length(uniquednames) < nrow(x))
@@ -62,8 +63,13 @@ dfm_compress <- function(x, margin = c("both", "documents", "features")) {
         new_j <- c(new_j, allZeroFeatures)
     }
     
+    if (nd <- length(allZeroDocs)) {
+        new_i <- c(new_i, allZeroDocs)
+        new_j <- c(new_j, rep(1, nd))
+    }
+
     new("dfmSparse", sparseMatrix(i = new_i, j = new_j, 
-                                  x = c(x@x, rep(0, length(allZeroFeatures))),
+                                  x = c(x@x, rep(0, length(allZeroFeatures)), rep(0, length(allZeroDocs))),
                                   dimnames = list(docs = uniquednames, features = uniquefnames)),
         settings = x@settings,
         weightTf = x@weightTf,

--- a/tests/testthat/test_dfm-compress.R
+++ b/tests/testthat/test_dfm-compress.R
@@ -1,0 +1,43 @@
+context("test dfm_compress")
+
+test_that("dfm_compress: simple test", {
+    mat <- rbind(dfm(c("b A A", "C C a b B"), tolower = FALSE, verbose = FALSE),
+                 dfm("A C C C C C", tolower = FALSE, verbose = FALSE))
+    colnames(mat) <- toLower(featnames(mat))
+    expect_equal(as.matrix(dfm_compress(mat, margin = "documents")),
+                 matrix(c(3,0,5,2,1,1,0,1,0,1), nrow = 2,
+                        dimnames = list(docs = c("text1", "text2"), features = featnames(mat))))
+    expect_equal(
+        as.matrix(dfm_compress(mat, margin = "features")),
+        matrix(c(2,1,1,0,2,5,1,2,0), nrow = 3,
+               dimnames = list(docs = docnames(mat), features = c("a", "c", "b")))
+    )
+    expect_equal(
+        as.matrix(dfm_compress(mat, margin = "both")),
+        matrix(c(3,1,5,2,1,2), nrow = 2,
+               dimnames = list(docs = c("text1", "text2"), features = c("a", "c", "b")))
+    )
+})
+
+
+test_that("dfm_compress: no effect if no compression needed", {
+    compactdfm <- dfm(data_char_inaugural[1:5], tolower = TRUE, verbose = FALSE)
+    expect_equal(dim(compactdfm), dim(dfm_compress(compactdfm)))
+})
+
+test_that("dfm_compress: empty features are preserved", {
+    testdfm <- new("dfmSparse", Matrix::Matrix(matrix(c(0,0,0, 2,1,5, 0,1,0, 1,1,0), nrow = 3,
+                                                      dimnames = list(docs = paste0("d", 1:3),
+                                                                      features = c("a", "b", "c", "b"))),
+                                               sparse = TRUE))
+    expect_equal(colSums(dfm_compress(testdfm))[1], c(a = 0))
+})
+
+test_that("dfm_compress: empty documents are preserved", {
+    testdfm <- new("dfmSparse", Matrix::Matrix(matrix(c(0,0,0, 2,1,0, 0,1,0, 1,1,0), nrow = 3,
+                                                      dimnames = list(docs = paste0("d", 1:3),
+                                                                      features = c("a", "b", "c", "b"))),
+                                               sparse = TRUE))
+    expect_equal(rowSums(dfm_compress(testdfm))[3], c(d3 = 0))
+})
+


### PR DESCRIPTION
The bug happened when there were documents with zero features, and it tried to recompile the sparse matrix index.  Previously this was fixed for zero-frequency features, but not for zero-frequency documents.

Also added new tests for these conditions.