### PR TITLE
Issue 497

### DIFF
--- a/src/quanteda.h
+++ b/src/quanteda.h
@@ -94,15 +94,14 @@ namespace ngrams {
 
 #if RCPP_PARALLEL_USE_TBB
     // TBB header is loaded automatically by the macro
-    typedef tbb::atomic<int> IdNgram; // tbb::atomic does not suppport unsigined int
-    //typedef int IdNgram;
+    typedef tbb::atomic<unsigned int> IdNgram;
     typedef tbb::concurrent_unordered_multimap<Ngram, unsigned int, hash_ngram, equal_ngram> MultiMapNgrams;
     typedef tbb::concurrent_unordered_map<Ngram, unsigned int, hash_ngram, equal_ngram> MapNgrams;
     typedef tbb::concurrent_unordered_set<Ngram, hash_ngram, equal_ngram> SetNgrams;
     typedef tbb::concurrent_vector<Ngram> VecNgrams;
     typedef tbb::concurrent_unordered_set<unsigned int> SetUnigrams;
 #else
-    typedef int IdNgram;
+    typedef unsigned int IdNgram;
     typedef std::unordered_multimap<Ngram, unsigned int, hash_ngram, equal_ngram> MultiMapNgrams;
     typedef std::unordered_map<Ngram, unsigned int, hash_ngram, equal_ngram> MapNgrams;
     typedef std::unordered_set<Ngram, hash_ngram, equal_ngram> SetNgrams;

--- a/src/tokens_lookup_mt.cpp
+++ b/src/tokens_lookup_mt.cpp
@@ -15,7 +15,7 @@ Text lookup(Text tokens,
     
     if(tokens.size() == 0) return {}; // return empty vector for empty text
     
-    std::size_t n;
+    std::size_t n = 0;
     std::vector< std::vector<unsigned int> > keys(tokens.size()); 
     for (std::size_t span : spans) { // substitution starts from the longest sequences
         if (tokens.size() < span) continue;
@@ -33,7 +33,8 @@ Text lookup(Text tokens,
     // Flatten the vector of vector
     Text keys_flat;
     keys_flat.reserve(n);
-    for (const auto &key_sub: keys) {
+    for (auto &key_sub: keys) {
+        std::sort(key_sub.begin(), key_sub.end()); // sort in order of keys
         keys_flat.insert(keys_flat.end(), key_sub.begin(), key_sub.end());                                                                                         
     }
     return keys_flat;
@@ -118,7 +119,6 @@ dict <- list(5, c(5, 6) , 4)
 #dict <- list(1, 10, 20)
 keys <- 1:length(dict)
 qatd_cpp_tokens_lookup(toks, dict, keys)
-
 
 
 */

--- a/src/tokens_lookup_mt.cpp
+++ b/src/tokens_lookup_mt.cpp
@@ -15,8 +15,8 @@ Text lookup(Text tokens,
     
     if(tokens.size() == 0) return {}; // return empty vector for empty text
     
-    Text keys;
-    keys.reserve(tokens.size());
+    std::size_t n;
+    std::vector< std::vector<unsigned int> > keys(tokens.size()); 
     for (std::size_t span : spans) { // substitution starts from the longest sequences
         if (tokens.size() < span) continue;
         for (std::size_t i = 0; i < tokens.size() - (span - 1); i++) {
@@ -24,13 +24,19 @@ Text lookup(Text tokens,
             auto range = map_keys.equal_range(ngram);
             for (auto it = range.first; it != range.second; ++it){
                 //Rcout << it->second << "\n";
-                keys.push_back(it->second);
+                keys[i].push_back(it->second); // keep multiple keys in the same position
+                n++;
             }
-            
         }
     }
-    std::sort(keys.begin(), keys.end()); // solve system dependency
-    return keys;
+    
+    // Flatten the vector of vector
+    Text keys_flat;
+    keys_flat.reserve(n);
+    for (const auto &key_sub: keys) {
+        keys_flat.insert(keys_flat.end(), key_sub.begin(), key_sub.end());                                                                                         
+    }
+    return keys_flat;
 }
 
 
@@ -108,9 +114,10 @@ List qatd_cpp_tokens_lookup(const List &texts_,
 
 toks <- list(rep(1:10, 1), rep(5:15, 1))
 dict <- list(c(1, 2), c(5, 6), 10, 15, 20)
+dict <- list(5, c(5, 6) , 4)
 #dict <- list(1, 10, 20)
-key <- 1:length(dict)
-qatd_cpp_tokens_lookup(toks, dict, key)
+keys <- 1:length(dict)
+qatd_cpp_tokens_lookup(toks, dict, keys)
 
 
 

--- a/src/tokens_ngrams_mt.cpp
+++ b/src/tokens_ngrams_mt.cpp
@@ -1,5 +1,5 @@
 #include <Rcpp.h>
-#include "dev.h"
+//#include "dev.h"
 #include "quanteda.h"
 
 // [[Rcpp::plugins(cpp11)]]

--- a/tests/testthat/test-tokens_lookup.R
+++ b/tests/testthat/test-tokens_lookup.R
@@ -200,15 +200,15 @@ test_that("#459 apply a hierarchical dictionary", {
             swords = c("States"))))
     
     expect_equal(as.list(tokens_lookup(toks, dict, valuetype = "fixed", levels=1)),
-                 list(d1 = c("geo", "geo", "geo", "other"),
+                 list(d1 = c("geo", "other", "geo", "geo"),
                       d2 = c("geo", "other")))
     
     expect_equal(as.list(tokens_lookup(toks, dict, valuetype = "fixed", levels=1:2)),
-                 list(d1 = c("geo.Countries", "geo.oceans", "geo.oceans", "other.swords"),
+                 list(d1 = c("geo.Countries", "other.swords", "geo.oceans", "geo.oceans"),
                       d2 = c("geo.Countries", "other.swords")))
     
     expect_equal(as.list(tokens_lookup(toks, dict, valuetype = "fixed", levels=2)),
-                 list(d1 = c("Countries", "oceans", "oceans", "swords"),
+                 list(d1 = c("Countries", "swords", "oceans", "oceans"),
                       d2 = c("Countries", "swords")))
 })
 

--- a/tests/testthat/test-tokens_lookup.R
+++ b/tests/testthat/test-tokens_lookup.R
@@ -87,8 +87,8 @@ test_that("multi-word dictionary behavior is not sensitive to the order of dicti
     dict2 <- dictionary(list(team = c("Arsenal", "Manchester United"),
                              Countries = c("United States")))
     expect_equal(
-        lapply(as.list(tokens_lookup(toks, dictionary = dict1, valuetype = "fixed")), sort),
-        lapply(as.list(tokens_lookup(toks, dictionary = dict2, valuetype = "fixed")), sort)
+        as.list(tokens_lookup(toks, dictionary = dict1, valuetype = "fixed")),
+        as.list(tokens_lookup(toks, dictionary = dict2, valuetype = "fixed"))
     )
     
 })
@@ -103,7 +103,7 @@ test_that("#388 issue about overlapping key values is resolved: fixed matches", 
                                   swords = c("States")))
     
     expect_equal(as.list(tokens_lookup(toks, dict_fixed, valuetype = "fixed")),
-                 list(d1 = c("Countries", "oceans", "oceans", "swords"),
+                 list(d1 = c("Countries", "swords", "oceans", "oceans"),
                       d2 = c("Countries", "swords")))
 })
 
@@ -117,10 +117,10 @@ test_that("#388 issue about overlapping key values is resolved: glob matches", {
                                  swords = "*s"))
 
     expect_equal(as.list(tokens_lookup(toks, dict_glob, valuetype = "glob")),
-              list(d1 = c("Countries", "oceans", "oceans", "swords", "swords"),
-                   d2 = c("Countries", "Countries", "swords", "swords")))
+              list(d1 = c("Countries", "swords", "swords", "oceans", "oceans"),
+                   d2 = c("Countries", "swords", "swords", "Countries")))
     expect_equal(as.list(tokens_lookup(toks, dict_glob, valuetype = "glob", case_insensitive = FALSE)),
-                 list(d1 = c("Countries", "oceans", "oceans", "swords", "swords"),
+                 list(d1 = c("Countries", "swords", "swords", "oceans", "oceans"),
                       d2 = c("Countries", "swords", "swords")))
 })
 
@@ -134,10 +134,10 @@ test_that("#388 issue about overlapping key values is resolved: regex matches", 
                                   swords = "s$"))
 
     expect_equal(as.list(tokens_lookup(toks, dict_regex, valuetype = "regex")),
-                 list(d1 = c("Countries", "oceans", "oceans", "swords", "swords"),
-                      d2 = c("Countries", "Countries", "swords", "swords")))
+                 list(d1 = c("Countries", "swords", "swords", "oceans", "oceans"),
+                      d2 = c("Countries", "swords", "swords", "Countries")))
     expect_equal(as.list(tokens_lookup(toks, dict_regex, valuetype = "regex", case_insensitive = FALSE)),
-                 list(d1 = c("Countries", "oceans", "oceans", "swords", "swords"),
+                 list(d1 = c("Countries", "swords", "swords", "oceans", "oceans"),
                       d2 = c("Countries", "swords", "swords")))
     
 })


### PR DESCRIPTION
This is an attempt to solve #497 by keeping the order of tokens as much as possible when `exclusive=TRUE`. The impact of the speed would be small, but need to be checked with large datasets.