### PR TITLE
Add multiword argument to solve #500.

### DIFF
--- a/man/tokens_lookup.Rd
+++ b/man/tokens_lookup.Rd
@@ -5,8 +5,8 @@
 \title{apply a dictionary to a tokens object}
 \usage{
 tokens_lookup(x, dictionary, levels = 1:5, valuetype = c("glob", "regex",
-  "fixed"), case_insensitive = TRUE, capkeys = FALSE, concatenator = " ",
-  exclusive = TRUE, verbose = FALSE)
+  "fixed"), concatenator = " ", case_insensitive = TRUE, capkeys = FALSE,
+  exclusive = TRUE, multiword = TRUE, verbose = FALSE)
 }
 \arguments{
 \item{x}{tokens object to which dictionary or thesaurus will be supplied}
@@ -25,17 +25,20 @@ the first.  (See examples.)}
 "glob"-style wildcard expressions; \code{"regex"} for regular expressions;
 or \code{"fixed"} for exact matching. See \link{valuetype} for details.}
 
+\item{concatenator}{a charactor that connect words in multi-words entries in \code{x}}
+
 \item{case_insensitive}{ignore the case of dictionary values if \code{TRUE} 
 uppercase to distinguish them from other features}
 
 \item{capkeys}{if TRUE, convert dictionary keys to uppercase to distinguish 
 them from other features}
 
-\item{concatenator}{a charactor that connect words in multi-words entries}
-
 \item{exclusive}{if \code{TRUE}, remove all features not in dictionary, 
 otherwise, replace values in dictionary with keys while leaving other 
 features unaffected}
+
+\item{multiword}{if \code{FALSE}, multi-word entries in dictionary are treated
+as single tokens}
 
 \item{verbose}{print status messages if \code{TRUE}}
 }

--- a/tests/testthat/test-tokens_lookup.R
+++ b/tests/testthat/test-tokens_lookup.R
@@ -166,8 +166,6 @@ test_that("tokens_lookup preserves case on keys", {
                      c("Country", "HOR"))
 })
 
-
-
 test_that("multi-word dictionary behavior is not affected by padding", {
     
     toks <- tokens(c(d1 = "Mexico signed a new libertarian law with Canada.",
@@ -240,3 +238,37 @@ test_that("#480 reset padding flag", {
                             HOR = c("House of Re*")))
     expect_false('' %in% featnames(dfm(tokens_lookup(toks, dict, exclusive = TRUE), tolower = FALSE)))
 })
+
+
+test_that("#500 tokens_lookup separates entry words by concatenator", {
+    
+    toks <- tokens(data_corpus_inaugural[1:5])
+    dict <- dictionary(list(Country = "united_states",
+                            HOR = c("House_of_Re*")), concatenator = '_')
+    expect_identical(featnames(dfm(tokens_lookup(toks, dict), tolower = FALSE)),
+                     c("Country", "HOR"))
+})
+
+
+test_that("#500 tokens_lookup do not separate words when multiword = FALSE", {
+    toks <- as.tokens(list(d1 = c('United States', 'Atlantic Ocean', 'Pacific Ocean'),
+                           d2 = c('Supreme Court', 'United States')))
+    dict <- dictionary(list(Countries = c("United States"),
+                            oceans = c("Atlantic *", "Pacific *")))
+    
+    expect_equal(as.list(tokens_lookup(toks, dict, valuetype = "glob", multiword = FALSE)),
+                 list(d1 = c("Countries", "oceans", "oceans"),
+                      d2 = c("Countries")))
+})
+
+test_that("#500 tokens_lookup substitute concatenator", {
+    toks <- as.tokens(list(d1 = c('United-States', 'Atlantic-Ocean', 'Pacific-Ocean'),
+                           d2 = c('Supreme-Court', 'United-States')))
+    dict <- dictionary(list(Countries = c("United_States"),
+                            oceans = c("Atlantic_*", "Pacific_*")), concatenator = '_')
+    
+    expect_equal(as.list(tokens_lookup(toks, dict, valuetype = "glob", concatenator = '-', multiword = FALSE)),
+                 list(d1 = c("Countries", "oceans", "oceans"),
+                      d2 = c("Countries")))
+})
+


### PR DESCRIPTION
This is for #500, adding functionality to `tokens_lookup` that apply a dictionary to `tokens` whose multi-word features are already concatenated. Please rename the `multiword` argument to something better.  