### PR TITLE
Issue 526

### DIFF
--- a/R/convert.R
+++ b/R/convert.R
@@ -301,8 +301,10 @@ ijv.to.doc <- function(i, j, v) {
 #' @keywords internal
 dfm2lsa <- function(x) {
     x <- as.matrix(x)
+    # convert to integer
+    x <- apply(x, c(1,2), as.integer)
     class(x) = "textmatrix"
-    names(dimnames(x)) <- c("terms", "docs") 
+    names(dimnames(x)) <- c("docs", "terms") 
     t(x)
 }
     

--- a/R/dictionaries-deprecated.R
+++ b/R/dictionaries-deprecated.R
@@ -120,6 +120,7 @@ applyDictionary.tokens <- function(x, dictionary, exclusive = TRUE,
     attributes(newtokens) <- attr_orig
     attr(newtokens, "types") <- NULL  # get rid of types, so we can recompile
     class(newtokens) <- class(newtokens)[-1]  # remove tokens class tag
+    class(newtokens) <- c(class(newtokens), "list") # add list tag
     # reverse the NA
     if (length(emptydocs))
         newtokens[emptydocs] <- list(rep(character(0), length(emptydocs)))

--- a/R/tokens.R
+++ b/R/tokens.R
@@ -293,13 +293,19 @@ as.tokens <- function(x) {
 #' @rdname as.tokens
 #' @export
 as.tokens.list <- function(x) {
-    tokens_hash(x)
+    result <- tokens_hash(x)
+    attr(result, "what") <- "word"
+    attr(result, "ngrams") <- 1L
+    attr(result, "concatenator") <- ""
+    attr(result, 'padding') <- FALSE
+    class(result)[2] <- "tokenizedTexts"
+    result
 }
 
 #' @export
 #' @noRd
 as.tokens.tokenizedTexts <- function(x) {
-    tokens_hash(x)
+    NextMethod("as.tokens")
 }
 
 #' @rdname as.tokens

--- a/tests/testthat/test-convert.R
+++ b/tests/testthat/test-convert.R
@@ -43,3 +43,25 @@ test_that("test topicmodels package converter", {
 test_that("test austin package converter", {
     expect_identical(convert(d, to = "austin"), quanteda::as.wfm(d))
 })
+
+test_that("test lsa converter", {
+    skip_if_not_installed("lsa")
+    # create some files
+    td = tempfile()
+    dir.create(td)
+    write( c("cat", "dog", "mouse"), file=paste(td, "D1", sep="/") )
+    write( c("hamster", "mouse", "sushi"), file=paste(td, "D2", sep="/") )
+    write( c("dog", "monster", "monster"), file=paste(td, "D3", sep="/") )
+    # read them, create a document-term matrix
+    lsamat <- lsa::textmatrix(td)
+    
+    lsamat2 <- convert(dfm(tokens(c(D1 =  c("cat dog mouse"),
+                                    D2 = c("hamster mouse sushi"), 
+                                    D3 = c("dog monster monster")))),
+                       to = "lsa")
+    expect_equivalent(lsamat, lsamat2)    
+    
+})
+
+
+

--- a/tests/testthat/test-convert.R
+++ b/tests/testthat/test-convert.R
@@ -46,6 +46,7 @@ test_that("test austin package converter", {
 
 test_that("test lsa converter", {
     skip_if_not_installed("lsa")
+    require(lsa)
     # create some files
     td <- tempfile()
     dir.create(td)

--- a/tests/testthat/test-convert.R
+++ b/tests/testthat/test-convert.R
@@ -47,15 +47,15 @@ test_that("test austin package converter", {
 test_that("test lsa converter", {
     skip_if_not_installed("lsa")
     # create some files
-    td = tempfile()
+    td <- tempfile()
     dir.create(td)
-    write( c("cat", "dog", "mouse"), file=paste(td, "D1", sep="/") )
-    write( c("hamster", "mouse", "sushi"), file=paste(td, "D2", sep="/") )
-    write( c("dog", "monster", "monster"), file=paste(td, "D3", sep="/") )
+    write( c("cat", "dog", "mouse"), file = paste(td, "D1", sep="/") )
+    write( c("hamster", "mouse", "sushi"), file = paste(td, "D2", sep="/") )
+    write( c("dog", "monster", "monster"), file = paste(td, "D3", sep="/") )
     # read them, create a document-term matrix
     lsamat <- lsa::textmatrix(td)
     
-    lsamat2 <- convert(dfm(tokens(c(D1 =  c("cat dog mouse"),
+    lsamat2 <- convert(dfm(tokens(c(D1 = c("cat dog mouse"),
                                     D2 = c("hamster mouse sushi"), 
                                     D3 = c("dog monster monster")))),
                        to = "lsa")

--- a/tests/testthat/test-tokens.R
+++ b/tests/testthat/test-tokens.R
@@ -75,6 +75,16 @@ test_that("as.tokens list version works as expected", {
                       as.tokens(toks))
 })
 
+test_that("as.tokens list version works as expected", {
+    txt <- c(doc1 = "The first sentence is longer than the second.",
+             doc2 = "Told you so.")
+    tokslist <- as.list(tokens(txt))
+    toks <- tokens(txt)
+    expect_equal(as.tokens(tokslist), 
+                      toks)
+})
+
+
 test_that("tokens indexing works as expected", {
     toks <- tokens(c(d1 = "one two three", d2 = "four five six", d3 = "seven eight"))
 


### PR DESCRIPTION
Fixes #526 and improves the operation of `as.tokens.list()` and `as.tokens.tokenizedTexts()`.

Adds tests for `convert(x, to = "lsa")`.