### PR TITLE
Dfm tokens lookup

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 * `tokens_lookup()` implements new rules for nested and linked sequences in dictionary values.  See #502.
 * `tokens_compound()` has a new `join` argument for better handling of nested and linked sequences.  See #517.
 * Internal operations on `tokens` are now significantly faster due to a reimplementation of the hash table functions in C++. (#510)
+* `dfm()` now works with multi-word dictionaries and thesauruses, which previously worked only with `tokens_lookup()`.
 
 ### Bug fixes
 

--- a/R/dfm.R
+++ b/R/dfm.R
@@ -239,6 +239,20 @@ dfm.tokenizedTexts <- function(x,
         names(x) <- paste("text", 1:length(x), sep="")
     } 
     
+    # use tokens_lookup for dictionaries with multi-word values otherwise do this later
+    if (!is.null(dictionary) | !is.null(thesaurus)) {
+        if (!is.null(thesaurus)) dictionary <- dictionary(thesaurus)
+        if (any(stringi::stri_detect_fixed(unlist(dictionary, use.names = FALSE), 
+                                           attr(dictionary, 'concatenator')))) {
+            if (verbose) catm("   ... ")
+            x <- tokens_lookup(x, dictionary,
+                               exclusive = ifelse(!is.null(thesaurus), FALSE, TRUE),
+                               valuetype = valuetype,
+                               verbose = verbose)
+            dictionary <- thesaurus <- NULL
+        }
+    }
+        
     # compile the dfm
     dfmresult <- compile_dfm(x, verbose = verbose)
     

--- a/R/tokens_lookup.R
+++ b/R/tokens_lookup.R
@@ -57,7 +57,7 @@ tokens_lookup <- function(x, dictionary, levels = 1:5,
                           valuetype = c("glob", "regex", "fixed"), 
                           concatenator = ' ',
                           case_insensitive = TRUE,
-                          capkeys = FALSE,
+                          capkeys = !exclusive,
                           exclusive = TRUE,
 #                          overlap = FALSE,
                           multiword = TRUE,
@@ -71,7 +71,7 @@ tokens_lookup.tokens <- function(x, dictionary, levels = 1:5,
                           valuetype = c("glob", "regex", "fixed"), 
                           concatenator = ' ',
                           case_insensitive = TRUE,
-                          capkeys = FALSE,
+                          capkeys = !exclusive,
                           exclusive = TRUE,
 #                          overlap = FALSE,
                           multiword = TRUE,
@@ -98,7 +98,9 @@ tokens_lookup.tokens <- function(x, dictionary, levels = 1:5,
     
     index <- index_regex(types, valuetype, case_insensitive) # index types before the loop
     if (verbose) 
-        message('Registering ', length(unlist(dictionary)), ' entries in the dictionary...');
+        catm("applying a dictionary consisting of ", length(dictionary), " key", 
+             ifelse(length(dictionary) > 1, "s", ""), "\n", sep="")
+    
     for (h in 1:length(dictionary)) {
         entries <- dictionary[[h]]
         
@@ -117,22 +119,22 @@ tokens_lookup.tokens <- function(x, dictionary, levels = 1:5,
         entries_id <- c(entries_id, entries_temp)
         keys_id <- c(keys_id, rep(h, length(entries_temp)))
     }
-    if (verbose) 
-        message('Searching ', length(entries_id), ' types of features...')
+    # if (verbose) 
+    #     message('Searching ', length(entries_id), ' types of features...')
     
-    if(exclusive){
+    if (exclusive) {
         x <- qatd_cpp_tokens_lookup(x, entries_id, keys_id, overlap)
-    }else{
+    } else {
         x <- qatd_cpp_tokens_match(x, entries_id, keys_id + length(types), FALSE)
     }
     attributes(x) <- attrs_org
-    if(exclusive){
+    if (exclusive) {
         if (capkeys) {
             types(x) <- char_toupper(names(dictionary))
         } else {
             types(x) <- names(dictionary)
         }
-    }else{
+    } else {
         if (capkeys) {
             types(x) <- c(types, char_toupper(names(dictionary)))
         } else {

--- a/man/tokens_lookup.Rd
+++ b/man/tokens_lookup.Rd
@@ -5,8 +5,9 @@
 \title{apply a dictionary to a tokens object}
 \usage{
 tokens_lookup(x, dictionary, levels = 1:5, valuetype = c("glob", "regex",
-  "fixed"), concatenator = " ", case_insensitive = TRUE, capkeys = FALSE,
-  exclusive = TRUE, multiword = TRUE, verbose = FALSE)
+  "fixed"), concatenator = " ", case_insensitive = TRUE,
+  capkeys = !exclusive, exclusive = TRUE, multiword = TRUE,
+  verbose = FALSE)
 }
 \arguments{
 \item{x}{tokens object to which dictionary or thesaurus will be supplied}

--- a/tests/testthat/test-dfm.R
+++ b/tests/testthat/test-dfm.R
@@ -362,13 +362,12 @@ test_that("dfm(x, dictionary = mwvdict) works with multi-word values", {
     dfm2 <- dfm(txt, thesaurus = mwvdict, verbose = TRUE)
     expect_identical(
         as.matrix(dfm2), 
-        matrix(c(1, 0, 0, 0, 1, 0, 1, 0, 2, 1, 0, 0),
+        matrix(c(0, 1, 0, 0,  1, 1, 0, 0,  1, 0, 0, 1,  1, 0, 0, 1,  0, 1, 0, 0, 1, 1, 0, 0, 
+                 1, 0, 0, 0, 1, 0, 1, 0, 2, 1, 0, 0),
                nrow = 4,
                dimnames = list(docs = paste0("d", 1:4), 
-                               features = c("sequence1", "sequence2", "notseq")))
-        
+                               features = c("a", "c", "f", "g", "x", "z", 
+                                            "SEQUENCE1", "SEQUENCE2", "NOTSEQ")))
     )
-    
-    
 })
 

--- a/tests/testthat/test-dfm.R
+++ b/tests/testthat/test-dfm.R
@@ -341,3 +341,34 @@ test_that("rbind.dfm works as expected",{
                  c("docs", "features"))
 })
 
+test_that("dfm(x, dictionary = mwvdict) works with multi-word values", {
+    mwvdict <- dictionary(list(sequence1 = "a b", sequence2 = "x y", notseq = c("d", "e")))
+    txt <- c(d1 = "a b c d e f g x y z",
+             d2 = "a c d x z",
+             d3 = "x y",
+             d4 = "f g")
+
+    # as dictionary
+    dfm1 <- dfm(txt, dictionary = mwvdict, verbose = TRUE)
+    expect_identical(
+        as.matrix(dfm1), 
+        matrix(c(1, 0, 0, 0, 1, 0, 1, 0, 2, 1, 0, 0),
+               nrow = 4,
+               dimnames = list(docs = paste0("d", 1:4), 
+                               features = c("sequence1", "sequence2", "notseq")))
+    )
+    
+    # as thesaurus
+    dfm2 <- dfm(txt, thesaurus = mwvdict, verbose = TRUE)
+    expect_identical(
+        as.matrix(dfm2), 
+        matrix(c(1, 0, 0, 0, 1, 0, 1, 0, 2, 1, 0, 0),
+               nrow = 4,
+               dimnames = list(docs = paste0("d", 1:4), 
+                               features = c("sequence1", "sequence2", "notseq")))
+        
+    )
+    
+    
+})
+

--- a/tests/testthat/test-dfm_lookup.R
+++ b/tests/testthat/test-dfm_lookup.R
@@ -9,7 +9,7 @@ test_that("test dfm_lookup, issue #389", {
                             freedom = c('free*', 'libert*')))
     expect_equal(featnames(dfm(tokens_lookup(toks, dictionary = dict), tolower = FALSE)),
                  c("Country", "HOR", "law", "freedom"))
-    expect_error(dfm(toks, dictionary = dict),
+    expect_error(dfm_lookup(dfm(toks), dictionary = dict),
                   "dfm_lookup not currently implemented for ngrams > 1 and multi-word dictionary values")
 
     dict2 <- dictionary(list(Country = "united",


### PR DESCRIPTION
Allows `dfm(x, dictionary = something)` where something is a dictionary with multi-word values. This happens by calling `tokens_lookup` before constructing the dfm, if  the dictionary contains any multi-word values. Otherwise it calls `dfm_lookup` internally after compiling the dfm, which is generally faster.

Solves #544.