### PR TITLE
Issue 607

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -81,15 +81,15 @@ qatd_cpp_chars_remove <- function(input_, char_remove) {
     .Call('quanteda_qatd_cpp_chars_remove', PACKAGE = 'quanteda', input_, char_remove)
 }
 
+wordfishcpp <- function(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor) {
+    .Call('quanteda_wordfishcpp', PACKAGE = 'quanteda', wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor)
+}
+
 wordfishcpp_dense <- function(wfm, dir, priors, tol, disp, dispfloor, abs_err) {
     .Call('quanteda_wordfishcpp_dense', PACKAGE = 'quanteda', wfm, dir, priors, tol, disp, dispfloor, abs_err)
 }
 
 wordfishcpp_mt <- function(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_sparse, residual_floor) {
     .Call('quanteda_wordfishcpp_mt', PACKAGE = 'quanteda', wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_sparse, residual_floor)
-}
-
-wordfishcpp <- function(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor) {
-    .Call('quanteda_wordfishcpp', PACKAGE = 'quanteda', wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor)
 }
 

--- a/R/collocations.R
+++ b/R/collocations.R
@@ -70,9 +70,6 @@ NULL
 collocations <- function(x,  method = c("lr", "chi2", "pmi", "dice", "all"), size = 2, 
                          n = NULL, tolower = TRUE, 
                          punctuation = c("dontspan", "ignore", "include"), ...) {
-#     addedArgs <- names(list(...))
-#     if (length(addedArgs) && any(!(addedArgs %in% names(formals(getS3method("tokenize", "character"))))))
-#         warning("Argument", ifelse(length(addedArgs)>1, "s ", " "), addedArgs, " not used.", sep = "", noBreaks. = TRUE)
     UseMethod("collocations")
 }
  
@@ -101,7 +98,7 @@ collocations.character <- function(x, method = c("lr", "chi2", "pmi", "dice", "a
                                    n = NULL, tolower = TRUE, 
                                    punctuation = c("dontspan", "ignore", "include"), ...) {
     method <- match.arg(method)
-    x <- tokens((if (tolower) char_tolower(x) else x), hash = FALSE, ...)
+    x <- tokens((if (tolower) char_tolower(x) else x), ...)
     collocations(x, method = method, size = size , n = n, punctuation = punctuation)
 }
 

--- a/R/tokens.R
+++ b/R/tokens.R
@@ -25,7 +25,8 @@
 #' @param remove_symbols if \code{TRUE}, remove all characters in the Unicode 
 #'   "Symbol" [S] class
 #' @param remove_twitter remove Twitter characters \code{@@} and \code{#}; set to
-#'   \code{TRUE} if you wish to eliminate these.
+#'   \code{TRUE} if you wish to eliminate these.  Note that this will always be set 
+#'   to \code{FALSE} if \code{remove_punct = FALSE}.
 #' @param remove_url if \code{TRUE}, find and eliminate URLs beginning with 
 #'   http(s) -- see section "Dealing with URLs".
 #' @param remove_hyphens if \code{TRUE}, split words that are connected by 
@@ -207,7 +208,7 @@ tokens.character <- function(x, what = c("word", "sentence", "character", "faste
     # disable remove_twitter if remove_punct = FALSE
     if (!remove_punct & remove_twitter) {
         remove_twitter <- FALSE
-        warning("remove_twitter reset to TRUE when remove_punct = FALSE")
+        warning("remove_twitter reset to FALSE when remove_punct = FALSE")
     }
     
     # warn about unused arguments

--- a/R/tokens.R
+++ b/R/tokens.R
@@ -204,6 +204,12 @@ tokens.character <- function(x, what = c("word", "sentence", "character", "faste
     names_org <- names(x)
     attrs_org <- attributes(x)
     
+    # disable remove_twitter if remove_punct = FALSE
+    if (!remove_punct & remove_twitter) {
+        remove_twitter <- FALSE
+        warning("remove_twitter reset to TRUE when remove_punct = FALSE")
+    }
+    
     # warn about unused arguments
     if (length(added_args <- list(...)) & 
         !all(names(added_args) %in% paste0("remove", c("Numbers", "Punct", "Symbols", "Separators", "Twitter", "Hyphens", "URL", "simplify")))) {
@@ -286,7 +292,11 @@ tokens.character <- function(x, what = c("word", "sentence", "character", "faste
     attr(result, "ngrams") <- ngrams
     attr(result, "concatenator") <- ifelse(all.equal(ngrams, 1L)==TRUE, "", concatenator)
     attr(result, 'padding') <- FALSE
-    
+
+    # issue #607: remove @ # only if not part of Twitter names
+    if (remove_punct & !remove_twitter)
+        result <- tokens_remove(result, "^#+$|^@+$", valuetype = "regex")
+
     return(result)
 }
 

--- a/man/tokens.Rd
+++ b/man/tokens.Rd
@@ -46,7 +46,8 @@ applicable for \code{what = "character"} (when you probably want it to be
 carefully.}
 
 \item{remove_twitter}{remove Twitter characters \code{@} and \code{#}; set to
-\code{TRUE} if you wish to eliminate these.}
+\code{TRUE} if you wish to eliminate these.  Note that this will always be set 
+to \code{FALSE} if \code{remove_punct = FALSE}.}
 
 \item{remove_hyphens}{if \code{TRUE}, split words that are connected by 
 hyphenation and hyphenation-like characters in between words, e.g. 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -281,6 +281,25 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// wordfishcpp
+Rcpp::List wordfishcpp(arma::sp_mat& wfm, IntegerVector& dirvec, NumericVector& priorvec, NumericVector& tolvec, IntegerVector& disptype, NumericVector& dispmin, bool ABS, bool svd_on, double residual_floor);
+RcppExport SEXP quanteda_wordfishcpp(SEXP wfmSEXP, SEXP dirvecSEXP, SEXP priorvecSEXP, SEXP tolvecSEXP, SEXP disptypeSEXP, SEXP dispminSEXP, SEXP ABSSEXP, SEXP svd_onSEXP, SEXP residual_floorSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< arma::sp_mat& >::type wfm(wfmSEXP);
+    Rcpp::traits::input_parameter< IntegerVector& >::type dirvec(dirvecSEXP);
+    Rcpp::traits::input_parameter< NumericVector& >::type priorvec(priorvecSEXP);
+    Rcpp::traits::input_parameter< NumericVector& >::type tolvec(tolvecSEXP);
+    Rcpp::traits::input_parameter< IntegerVector& >::type disptype(disptypeSEXP);
+    Rcpp::traits::input_parameter< NumericVector& >::type dispmin(dispminSEXP);
+    Rcpp::traits::input_parameter< bool >::type ABS(ABSSEXP);
+    Rcpp::traits::input_parameter< bool >::type svd_on(svd_onSEXP);
+    Rcpp::traits::input_parameter< double >::type residual_floor(residual_floorSEXP);
+    rcpp_result_gen = Rcpp::wrap(wordfishcpp(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor));
+    return rcpp_result_gen;
+END_RCPP
+}
 // wordfishcpp_dense
 Rcpp::List wordfishcpp_dense(SEXP wfm, SEXP dir, SEXP priors, SEXP tol, SEXP disp, SEXP dispfloor, bool abs_err);
 RcppExport SEXP quanteda_wordfishcpp_dense(SEXP wfmSEXP, SEXP dirSEXP, SEXP priorsSEXP, SEXP tolSEXP, SEXP dispSEXP, SEXP dispfloorSEXP, SEXP abs_errSEXP) {
@@ -314,25 +333,6 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< bool >::type svd_sparse(svd_sparseSEXP);
     Rcpp::traits::input_parameter< double >::type residual_floor(residual_floorSEXP);
     rcpp_result_gen = Rcpp::wrap(wordfishcpp_mt(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_sparse, residual_floor));
-    return rcpp_result_gen;
-END_RCPP
-}
-// wordfishcpp
-Rcpp::List wordfishcpp(arma::sp_mat& wfm, IntegerVector& dirvec, NumericVector& priorvec, NumericVector& tolvec, IntegerVector& disptype, NumericVector& dispmin, bool ABS, bool svd_on, double residual_floor);
-RcppExport SEXP quanteda_wordfishcpp(SEXP wfmSEXP, SEXP dirvecSEXP, SEXP priorvecSEXP, SEXP tolvecSEXP, SEXP disptypeSEXP, SEXP dispminSEXP, SEXP ABSSEXP, SEXP svd_onSEXP, SEXP residual_floorSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< arma::sp_mat& >::type wfm(wfmSEXP);
-    Rcpp::traits::input_parameter< IntegerVector& >::type dirvec(dirvecSEXP);
-    Rcpp::traits::input_parameter< NumericVector& >::type priorvec(priorvecSEXP);
-    Rcpp::traits::input_parameter< NumericVector& >::type tolvec(tolvecSEXP);
-    Rcpp::traits::input_parameter< IntegerVector& >::type disptype(disptypeSEXP);
-    Rcpp::traits::input_parameter< NumericVector& >::type dispmin(dispminSEXP);
-    Rcpp::traits::input_parameter< bool >::type ABS(ABSSEXP);
-    Rcpp::traits::input_parameter< bool >::type svd_on(svd_onSEXP);
-    Rcpp::traits::input_parameter< double >::type residual_floor(residual_floorSEXP);
-    rcpp_result_gen = Rcpp::wrap(wordfishcpp(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/tests/testthat/test-tokens.R
+++ b/tests/testthat/test-tokens.R
@@ -339,7 +339,7 @@ test_that("remove_punct and remove_twitter interact correctly, #607", {
     )
     expect_warning(
         tokens(txt, what = "word", remove_punct = FALSE, remove_twitter = TRUE),
-        "remove_twitter reset to TRUE when remove_punct = FALSE"
+        "remove_twitter reset to FALSE when remove_punct = FALSE"
     )
 })
 

--- a/tests/testthat/test-tokens.R
+++ b/tests/testthat/test-tokens.R
@@ -317,3 +317,29 @@ test_that("remove_url works as expected", {
     )
 })
 
+test_that("remove_punct and remove_twitter interact correctly, #607", {
+    txt <- "they: #stretched, @ @@ in,, a # ## never-ending @line."
+    expect_equal(
+        as.character(tokens(txt, what = "word", remove_punct = TRUE, remove_twitter = TRUE)),
+        c("they", "stretched", "in", "a", "never-ending", "line")
+    )    
+    expect_equal(
+        as.character(tokens(txt, what = "word", remove_punct = FALSE, remove_twitter = FALSE)),
+        c("they", ":", "#stretched", ",", "@", "@@", "in", ",", ",", "a", "#", "##", "never", "-", "ending", "@line", ".")
+    )    
+    # this is #607
+    expect_equal(
+        as.character(tokens(txt, what = "word", remove_punct = TRUE, remove_twitter = FALSE)),
+        c("they", "#stretched", "in", "a", "never-ending", "@line")
+    )
+    # remove_twitter should be inactive if remove_punct is FALSE
+    expect_equal(
+        as.character(tokens(txt, what = "word", remove_punct = FALSE, remove_twitter = TRUE)),
+        as.character(tokens(txt, what = "word", remove_punct = FALSE, remove_twitter = FALSE))
+    )
+    expect_warning(
+        tokens(txt, what = "word", remove_punct = FALSE, remove_twitter = TRUE),
+        "remove_twitter reset to TRUE when remove_punct = FALSE"
+    )
+})
+


### PR DESCRIPTION
Removes exclusively @ and # characters when `remove_punct = TRUE` and `remove_twitter = FALSE`. 

Also makes `remove_twitter = FALSE` always, when `remove_punct = FALSE`.
Adds tests
Fixes an issue in `collocations()`
Solves #607