### PR TITLE
Issue 567

### DIFF
--- a/R/dfm_select.R
+++ b/R/dfm_select.R
@@ -116,7 +116,7 @@ dfm_select.dfm <-  function(x, features = NULL, documents = NULL,
         features <- unlist(features, use.names = FALSE) # this funciton does not accpet list
         features_id <- unlist(regex2id(features, types, valuetype, case_insensitive), use.names = FALSE)
         features_id <- sort(features_id) # keep the original column order
-        
+
     } else {
         if (selection == "keep")
             features_id <- seq_len(nfeature(x))
@@ -125,9 +125,15 @@ dfm_select.dfm <-  function(x, features = NULL, documents = NULL,
     }
     
     if (!padding) {
+        
         # select features based on character length
-        features_id <- intersect(features_id, which(stringi::stri_length(types) >= min_nchar & 
-                                                    stringi::stri_length(types) <= max_nchar))
+        if (selection == "keep") {
+            features_id <- intersect(features_id, which(stringi::stri_length(types) >= min_nchar & 
+                                                        stringi::stri_length(types) <= max_nchar))
+        } else {
+            features_id <- union(features_id, which(stringi::stri_length(types) < min_nchar | 
+                                                    stringi::stri_length(types) > max_nchar))
+        }
     }
     
     # select documents based on "documents" pattern
@@ -188,6 +194,7 @@ dfm_select.dfm <-  function(x, features = NULL, documents = NULL,
             }
         }
     } else {
+
         if (length(features_id) == nfeature(x) || length(documents_id) == ndoc(x)) {
             x <- NULL    
         } else if(!length(features_id)) {

--- a/tests/testthat/test-dfm_select.R
+++ b/tests/testthat/test-dfm_select.R
@@ -27,16 +27,16 @@ test_that("test dfm_select, fixed", {
         c("BBB", "Aaaa")
     )
     expect_equal(
-        featnames(dfm_select(testdfm, c("aaaa", "bbb", "cc"), selection = "remove", valuetype = "fixed", min_nchar = 3, verbose = FALSE)),
-        c("a", "B", "c", "D", "e", "cc")
+        featnames(dfm_select(testdfm, c("bbb"), selection = "remove", valuetype = "fixed", min_nchar = 3, verbose = FALSE)),
+        c("Aaaa")
     )
     expect_equal(
         featnames(dfm_select(testdfm, c("aaaa", "bbb", "cc"), selection = "keep", valuetype = "fixed", min_nchar = 3, max_nchar = 3, verbose = FALSE)),
         c("BBB")
     )
     expect_equal(
-        featnames(dfm_select(testdfm, c("aaaa", "bbb", "cc"), selection = "remove", valuetype = "fixed", min_nchar = 3, max_nchar = 3, verbose = FALSE)),
-        c('a', 'B', 'c', 'D', 'e', 'Aaaa', 'cc')
+        featnames(dfm_select(testdfm, c("bbb"), selection = "remove", valuetype = "fixed", min_nchar = 3, max_nchar = 3, verbose = FALSE)),
+        NULL
     )
 })
 
@@ -64,7 +64,7 @@ test_that("test dfm_select, glob", {
     )
     expect_equal(
         featnames(dfm_select(testdfm, feats, selection = "remove", valuetype = "glob", min_nchar = 3, verbose = FALSE)),
-        c("a", "B", "c", "D", 'e', 'cc')
+        NULL
     )
 })
 
@@ -92,7 +92,7 @@ test_that("test dfm_select, regex", {
     )
     expect_equal(
         featnames(dfm_select(testdfm, feats, selection = "remove", valuetype = "regex", min_nchar = 3, verbose = FALSE)),
-        c("a", "B", "c", "D", "e", "cc")
+        NULL
     )
 })
 
@@ -115,7 +115,7 @@ test_that("selection that is out of bounds", {
 
     expect_equal(
         featnames(dfm_select(testdfm, selection = "remove", min_nchar = 5)),
-        featnames(testdfm)
+        NULL
     )
 
     # some tests for docnames and featnames
@@ -182,16 +182,16 @@ test_that("test dfm_select with features from a dfm,  fixed", {
              doc3 = "Aaaa BBB cc")
     testdfm <- dfm(txt, tolower = FALSE)  
     expect_equal(
-        colSums(dfm_select(testdfm, dfm(c("a", "b", "c")), case_insensitive = TRUE)),
+        colSums(dfm_select(testdfm, dfm(c("a", "b", "c")), case_insensitive = TRUE, min_nchar = 1)),
         c(a = 2, b = 0, c = 2)
     )
     expect_equal(
-        colSums(dfm_select(testdfm, dfm(c("a", "b", "c")), case_insensitive = FALSE)),
+        colSums(dfm_select(testdfm, dfm(c("a", "b", "c")), case_insensitive = FALSE, min_nchar = 1)),
         c(a = 2, b = 0, c = 2)
     )
     
     expect_equal(
-        colSums(dfm_select(testdfm, dfm(c("a", "b", "c")))),
+        colSums(dfm_select(testdfm, dfm(c("a", "b", "c")), min_nchar = 1)),
         c(a=2, b = 0, c=2)
     )
 })
@@ -203,6 +203,18 @@ test_that("dfm_select returns equal feature sets", {
     dfm2 <- dfm(txts[2:3])
     dfm3 <- dfm_select(dfm1, dfm2)
     expect_true(setequal(featnames(dfm2), featnames(dfm3)))
+})
+
+test_that("dfm_select removes padding", {
+    
+    txts <- c(d1 = "This is text one", d2 = "The second text", d3 = "This is text three")
+    toks <- tokens(txts)
+    toks <- tokens_remove(toks, stopwords(), padding = TRUE)
+    testdfm <- dfm(toks)
+    expect_true('' %in% featnames(testdfm))
+    testdfm <- dfm_remove(dfm(toks), '')
+    expect_false('' %in% featnames(testdfm))
+    
 })
 
 


### PR DESCRIPTION
This is to fix #567 by changing `dfm_select`'s add behavior when `selection = 'remove'`. In this mode, currently only features given to `features` that are longer than `min_nchar` and shorter than `max_nchar` had effect, but those specified by `features` _and_ those longer than `min_nchar` and shorter than `max_nchar` are removed:

```r
txts <- c(d1 = "This is text one", d2 = "The second text", d3 = "This is text three")
toks <- tokens(txts)
mx <- dfm(toks)

print(mx)

# Document-feature matrix of: 3 documents, 7 features (47.6% sparse).
# 3 x 7 sparse Matrix of class "dfmSparse"
# features
# docs this is text one the second three
# d1    1  1    1   1   0      0     0
# d2    0  0    1   0   1      1     0
# d3    1  1    1   0   0      0     1


dfm_select(mx, features = 'second', selection = 'remove', min_nchar = 3) # 'is' and 'second' are removed

# Document-feature matrix of: 3 documents, 5 features (46.7% sparse).
# 3 x 5 sparse Matrix of class "dfmSparse"
# features
# docs this text one the three
# d1    1    1   1   0     0
# d2    0    1   0   1     0
# d3    1    1   0   0     1
```
The current behavior:
```r
dfm_select(mx, features = 'second', selection = 'remove', min_nchar = 3) # only 'second' is removed

# Document-feature matrix of: 3 documents, 6 features (44.4% sparse).
# 3 x 6 sparse Matrix of class "dfmSparse"
# features
# docs this is text one the three
# d1    1  1    1   1   0     0
# d2    0  0    1   0   1     0
# d3    1  1    1   0   0     1
```