### PR TITLE
Fix #646

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -81,15 +81,15 @@ qatd_cpp_chars_remove <- function(input_, char_remove) {
     .Call('quanteda_qatd_cpp_chars_remove', PACKAGE = 'quanteda', input_, char_remove)
 }
 
+wordfishcpp <- function(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor) {
+    .Call('quanteda_wordfishcpp', PACKAGE = 'quanteda', wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor)
+}
+
 wordfishcpp_dense <- function(wfm, dir, priors, tol, disp, dispfloor, abs_err) {
     .Call('quanteda_wordfishcpp_dense', PACKAGE = 'quanteda', wfm, dir, priors, tol, disp, dispfloor, abs_err)
 }
 
 wordfishcpp_mt <- function(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_sparse, residual_floor) {
     .Call('quanteda_wordfishcpp_mt', PACKAGE = 'quanteda', wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_sparse, residual_floor)
-}
-
-wordfishcpp <- function(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor) {
-    .Call('quanteda_wordfishcpp', PACKAGE = 'quanteda', wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor)
 }
 

--- a/R/tokens.R
+++ b/R/tokens.R
@@ -313,7 +313,7 @@ tokens.character <- function(x, what = c("word", "sentence", "character", "faste
 tokens.corpus <- function(x, ..., include_docvars = TRUE) {
     result <- tokens(texts(x), ...)
     if (include_docvars) {
-        docvars(result) <- docvars(x, names(documents(x))[which(names(documents(x)) != "texts")])
+        docvars(result) <- documents(x)[, which(names(documents(x)) != "texts"), drop = FALSE]
     } else {
         docvars(result) <- data.frame(matrix(nrow = ndoc(result), ncol = 1)[, -1, drop = FALSE],
                                       row.names = docnames(result))

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -281,6 +281,25 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// wordfishcpp
+Rcpp::List wordfishcpp(arma::sp_mat& wfm, IntegerVector& dirvec, NumericVector& priorvec, NumericVector& tolvec, IntegerVector& disptype, NumericVector& dispmin, bool ABS, bool svd_on, double residual_floor);
+RcppExport SEXP quanteda_wordfishcpp(SEXP wfmSEXP, SEXP dirvecSEXP, SEXP priorvecSEXP, SEXP tolvecSEXP, SEXP disptypeSEXP, SEXP dispminSEXP, SEXP ABSSEXP, SEXP svd_onSEXP, SEXP residual_floorSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< arma::sp_mat& >::type wfm(wfmSEXP);
+    Rcpp::traits::input_parameter< IntegerVector& >::type dirvec(dirvecSEXP);
+    Rcpp::traits::input_parameter< NumericVector& >::type priorvec(priorvecSEXP);
+    Rcpp::traits::input_parameter< NumericVector& >::type tolvec(tolvecSEXP);
+    Rcpp::traits::input_parameter< IntegerVector& >::type disptype(disptypeSEXP);
+    Rcpp::traits::input_parameter< NumericVector& >::type dispmin(dispminSEXP);
+    Rcpp::traits::input_parameter< bool >::type ABS(ABSSEXP);
+    Rcpp::traits::input_parameter< bool >::type svd_on(svd_onSEXP);
+    Rcpp::traits::input_parameter< double >::type residual_floor(residual_floorSEXP);
+    rcpp_result_gen = Rcpp::wrap(wordfishcpp(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor));
+    return rcpp_result_gen;
+END_RCPP
+}
 // wordfishcpp_dense
 Rcpp::List wordfishcpp_dense(SEXP wfm, SEXP dir, SEXP priors, SEXP tol, SEXP disp, SEXP dispfloor, bool abs_err);
 RcppExport SEXP quanteda_wordfishcpp_dense(SEXP wfmSEXP, SEXP dirSEXP, SEXP priorsSEXP, SEXP tolSEXP, SEXP dispSEXP, SEXP dispfloorSEXP, SEXP abs_errSEXP) {
@@ -314,25 +333,6 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< bool >::type svd_sparse(svd_sparseSEXP);
     Rcpp::traits::input_parameter< double >::type residual_floor(residual_floorSEXP);
     rcpp_result_gen = Rcpp::wrap(wordfishcpp_mt(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_sparse, residual_floor));
-    return rcpp_result_gen;
-END_RCPP
-}
-// wordfishcpp
-Rcpp::List wordfishcpp(arma::sp_mat& wfm, IntegerVector& dirvec, NumericVector& priorvec, NumericVector& tolvec, IntegerVector& disptype, NumericVector& dispmin, bool ABS, bool svd_on, double residual_floor);
-RcppExport SEXP quanteda_wordfishcpp(SEXP wfmSEXP, SEXP dirvecSEXP, SEXP priorvecSEXP, SEXP tolvecSEXP, SEXP disptypeSEXP, SEXP dispminSEXP, SEXP ABSSEXP, SEXP svd_onSEXP, SEXP residual_floorSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< arma::sp_mat& >::type wfm(wfmSEXP);
-    Rcpp::traits::input_parameter< IntegerVector& >::type dirvec(dirvecSEXP);
-    Rcpp::traits::input_parameter< NumericVector& >::type priorvec(priorvecSEXP);
-    Rcpp::traits::input_parameter< NumericVector& >::type tolvec(tolvecSEXP);
-    Rcpp::traits::input_parameter< IntegerVector& >::type disptype(disptypeSEXP);
-    Rcpp::traits::input_parameter< NumericVector& >::type dispmin(dispminSEXP);
-    Rcpp::traits::input_parameter< bool >::type ABS(ABSSEXP);
-    Rcpp::traits::input_parameter< bool >::type svd_on(svd_onSEXP);
-    Rcpp::traits::input_parameter< double >::type residual_floor(residual_floorSEXP);
-    rcpp_result_gen = Rcpp::wrap(wordfishcpp(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/tests/testthat/test-docvars.R
+++ b/tests/testthat/test-docvars.R
@@ -170,3 +170,44 @@ test_that("creating tokens and dfms with empty docvars", {
     
 })
 
+test_that("tokens works works with one docvar", {
+    docv1 <- data.frame(dvar1 = c("A", "B"))
+    mycorpus1 <- corpus(c(d1 = "This is sample document one.",
+                          d2 = "Here is the second sample document."), 
+                        docvars = docv1)
+    toks1 <- tokens(mycorpus1, include_docvars = TRUE)
+    expect_equivalent(docvars(toks1), docv1)
+})
+
+
+test_that("tokens works works with two docvars", {
+    docv2 <- data.frame(dvar1 = c("A", "B"),
+                        dvar2 = c(1, 2))
+    mycorpus2 <- corpus(c(d1 = "This is sample document one.",
+                          d2 = "Here is the second sample document."), 
+                        docvars = docv2)
+    toks2 <- tokens(mycorpus2, include_docvars = TRUE)
+    expect_equivalent(docvars(toks2), docv2)
+})
+
+test_that("dfm works works with one docvar", {
+    docv1 <- data.frame(dvar1 = c("A", "B"))
+    mycorpus1 <- corpus(c(d1 = "This is sample document one.",
+                          d2 = "Here is the second sample document."), 
+                        docvars = docv1)
+    dfm1 <- dfm(mycorpus1, include_docvars = TRUE)
+    expect_equivalent(docvars(dfm1), docv1)
+})
+
+
+test_that("dfm works works with two docvars", {
+    docv2 <- data.frame(dvar1 = c("A", "B"),
+                        dvar2 = c(1, 2))
+    mycorpus2 <- corpus(c(d1 = "This is sample document one.",
+                          d2 = "Here is the second sample document."), 
+                        docvars = docv2)
+    dfm2 <- dfm(mycorpus2, include_docvars = TRUE)
+    expect_equivalent(docvars(dfm2), docv2)
+})
+
+


### PR DESCRIPTION
tokens and dfm objects created from a corpus with a single-variable docvar stay a data.frame in the tokens and dfm objects.