### PR TITLE
Issue 657

### DIFF
--- a/R/corpus_segment.R
+++ b/R/corpus_segment.R
@@ -246,7 +246,7 @@ get_delimiter <- function(what,
                           delimiter = NULL, 
                           valuetype) {
     if (!is.null(delimiter)) {
-        if (whichin <- (what %in% (whichtypes <- c("tokens", "sentences")))) {
+        if (any(whichin <- ((whichtypes <- c("tokens", "sentences")) %in% what))) {
             warning("delimiter is not used for ", whichtypes[which(whichin)])
             delimiter <- NULL
         }

--- a/tests/testthat/test-corpus_segment.R
+++ b/tests/testthat/test-corpus_segment.R
@@ -188,6 +188,10 @@ test_that("get_delimiter works as expected", {
         "##\\w+\\b"
     )
     expect_warning(
+        quanteda:::get_delimiter("sentences", " ", "regex"),
+        "delimiter is not used for sentences"
+    )
+    expect_warning(
         quanteda:::get_delimiter("tokens", " ", "regex"),
         "delimiter is not used for tokens"
     )
@@ -195,5 +199,13 @@ test_that("get_delimiter works as expected", {
         quanteda:::get_delimiter("other", NULL, "regex"),
         "For type other, you must supply a delimiter value"
     )
+
+})
+
+test_that("char_segment works with delimiter option", {
+    expect_is(char_segment(data_char_sampletext, what = "sentences"), "character")
+    expect_equal(length(char_segment(data_char_sampletext, what = "sentences")), 15)
+    
+    char_segment(data_char_sampletext, what = "sentences", delimiter = "\\.  ")
     
 })

--- a/vignettes/quickstart.html
+++ b/vignettes/quickstart.html
@@ -240,7 +240,7 @@ myCorpus &lt;-<span class="st"> </span><span class="kw">corpus</span>(data_char_
 ##   1805-Jefferson   804   2381        45
 ## 
 ## Source:  /Users/kbenoit/Dropbox (Personal)/GitHub/quanteda/vignettes/* on x86_64 by kbenoit
-## Created: Mon Apr  3 14:31:49 2017
+## Created: Sat Apr 15 14:32:25 2017
 ## Notes:</code></pre></div>
 <p>If we wanted, we could add some document-level variables – what quanteda calls <code>docvars</code> – to this corpus.</p>
 <p>We can do this using the R’s <code>substring()</code> function to extract characters from a name – in this case, the name of the character vector <code>data_char_inaugural</code>. This works using our fixed starting and ending positions with <code>substring()</code> because these names are a very regular format of <code>YYYY-PresidentName</code>.</p>
@@ -257,7 +257,7 @@ myCorpus &lt;-<span class="st"> </span><span class="kw">corpus</span>(data_char_
 ##   1805-Jefferson   804   2381        45  Jefferson 1805
 ## 
 ## Source:  /Users/kbenoit/Dropbox (Personal)/GitHub/quanteda/vignettes/* on x86_64 by kbenoit
-## Created: Mon Apr  3 14:31:49 2017
+## Created: Sat Apr 15 14:32:25 2017
 ## Notes:</code></pre></div>
 <p>If we wanted to tag each document with additional meta-data not considered a document variable of interest for analysis, but rather something that we need to know as an attribute of the document, we could also add those to our corpus.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">metadoc</span>(myCorpus, <span class="st">&quot;language&quot;</span>) &lt;-<span class="st"> &quot;english&quot;</span>
@@ -279,7 +279,7 @@ myCorpus &lt;-<span class="st"> </span><span class="kw">corpus</span>(data_char_
 ##  data_char_inaugural_5
 ## 
 ## Source:  /Users/kbenoit/Dropbox (Personal)/GitHub/quanteda/vignettes/* on x86_64 by kbenoit
-## Created: Mon Apr  3 14:31:49 2017
+## Created: Sat Apr 15 14:32:25 2017
 ## Notes:</code></pre></div>
 <p>The last command, <code>metadoc</code>, allows you to define your own document meta-data fields. Note that in assiging just the single value of <code>&quot;english&quot;</code>, R has recycled the value until it matches the number of documents in the corpus. In creating a simple tag for our custom metadoc field <code>docsource</code>, we used the quanteda function <code>ndoc()</code> to retrieve the number of documents in our corpus. This function is deliberately designed to work in a way similar to functions you may already use in R, such as <code>nrow()</code> and <code>ncol()</code>.</p>
 </div>
@@ -475,7 +475,7 @@ mycorpus3 &lt;-<span class="st"> </span>mycorpus1 +<span class="st"> </span>myco
 ##       2013-Obama   814   2335        88
 ## 
 ## Source:  Combination of corpuses mycorpus1 and mycorpus2
-## Created: Mon Apr  3 14:31:50 2017
+## Created: Sat Apr 15 14:32:26 2017
 ## Notes:</code></pre></div>
 </div>
 <div id="subsetting-corpus-objects" class="section level3">
@@ -513,32 +513,32 @@ mycorpus3 &lt;-<span class="st"> </span>mycorpus1 +<span class="st"> </span>myco
 <p>The <code>kwic</code> function (KeyWord In Context) performs a search for a word and allows us to view the contexts in which it occurs:</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">options</span>(<span class="dt">width =</span> <span class="dv">200</span>)
 <span class="kw">kwic</span>(data_corpus_inaugural, <span class="st">&quot;terror&quot;</span>)
-##                                                                                                      
-## [1797-Adams, 1327]                 fraud or violence, by | terror | , intrigue, or venality          
-## [1933-Roosevelt, 112] nameless, unreasoning, unjustified | terror | which paralyzes needed efforts to
-## [1941-Roosevelt, 289]      seemed frozen by a fatalistic | terror | , we proved that this            
-## [1961-Kennedy, 868]      alter that uncertain balance of | terror | that stays the hand of           
-## [1981-Reagan, 821]        freeing all Americans from the | terror | of runaway living costs.         
-## [1997-Clinton, 1055]         They fuel the fanaticism of | terror | . And they torment the           
-## [1997-Clinton, 1655]   maintain a strong defense against | terror | and destruction. Our children    
-## [2009-Obama, 1646]        advance their aims by inducing | terror | and slaughtering innocents, we
+##                                                                                                       
+##     [1797-Adams, 1327]              fraud or violence, by | terror | , intrigue, or venality          
+##  [1933-Roosevelt, 112] nameless, unreasoning, unjustified | terror | which paralyzes needed efforts to
+##  [1941-Roosevelt, 289]      seemed frozen by a fatalistic | terror | , we proved that this            
+##    [1961-Kennedy, 868]    alter that uncertain balance of | terror | that stays the hand of           
+##     [1981-Reagan, 821]     freeing all Americans from the | terror | of runaway living costs.         
+##   [1997-Clinton, 1055]        They fuel the fanaticism of | terror | . And they torment the           
+##   [1997-Clinton, 1655]  maintain a strong defense against | terror | and destruction. Our children    
+##     [2009-Obama, 1646]     advance their aims by inducing | terror | and slaughtering innocents, we
 <span class="kw">kwic</span>(data_corpus_inaugural, <span class="st">&quot;terror&quot;</span>, <span class="dt">valuetype =</span> <span class="st">&quot;regex&quot;</span>)
-##                                                                                                              
-## [1797-Adams, 1327]                      fraud or violence, by |  terror   | , intrigue, or venality          
-## [1933-Roosevelt, 112]      nameless, unreasoning, unjustified |  terror   | which paralyzes needed efforts to
-## [1941-Roosevelt, 289]           seemed frozen by a fatalistic |  terror   | , we proved that this            
-## [1961-Kennedy, 868]           alter that uncertain balance of |  terror   | that stays the hand of           
-## [1961-Kennedy, 992]                 of science instead of its |  terrors  | . Together let us explore        
-## [1981-Reagan, 821]             freeing all Americans from the |  terror   | of runaway living costs.         
-## [1981-Reagan, 2204]          understood by those who practice | terrorism | and prey upon their neighbors    
-## [1997-Clinton, 1055]              They fuel the fanaticism of |  terror   | . And they torment the           
-## [1997-Clinton, 1655]        maintain a strong defense against |  terror   | and destruction. Our children    
-## [2009-Obama, 1646]             advance their aims by inducing |  terror   | and slaughtering innocents, we   
-## [2017-Trump, 1119]    civilized world against radical Islamic | terrorism | , which we will eradicate
+##                                                                                                               
+##     [1797-Adams, 1327]                   fraud or violence, by |  terror   | , intrigue, or venality          
+##  [1933-Roosevelt, 112]      nameless, unreasoning, unjustified |  terror   | which paralyzes needed efforts to
+##  [1941-Roosevelt, 289]           seemed frozen by a fatalistic |  terror   | , we proved that this            
+##    [1961-Kennedy, 868]         alter that uncertain balance of |  terror   | that stays the hand of           
+##    [1961-Kennedy, 992]               of science instead of its |  terrors  | . Together let us explore        
+##     [1981-Reagan, 821]          freeing all Americans from the |  terror   | of runaway living costs.         
+##    [1981-Reagan, 2204]        understood by those who practice | terrorism | and prey upon their neighbors    
+##   [1997-Clinton, 1055]             They fuel the fanaticism of |  terror   | . And they torment the           
+##   [1997-Clinton, 1655]       maintain a strong defense against |  terror   | and destruction. Our children    
+##     [2009-Obama, 1646]          advance their aims by inducing |  terror   | and slaughtering innocents, we   
+##     [2017-Trump, 1119] civilized world against radical Islamic | terrorism | , which we will eradicate
 <span class="kw">kwic</span>(data_corpus_inaugural, <span class="st">&quot;communist*&quot;</span>)
-##                                                                                             
-## [1949-Truman, 838]  the actions resulting from the | Communist  | philosophy are a threat to
-## [1961-Kennedy, 519]             -- not because the | Communists | may be doing it,</code></pre></div>
+##                                                                                              
+##   [1949-Truman, 838] the actions resulting from the | Communist  | philosophy are a threat to
+##  [1961-Kennedy, 519]             -- not because the | Communists | may be doing it,</code></pre></div>
 <p>In the above summary, <code>Year</code> and <code>President</code> are variables associated with each document. We can access such variables with the <code>docvars()</code> function.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co"># inspect the document-level variables</span>
 <span class="kw">head</span>(<span class="kw">docvars</span>(data_corpus_inaugural))
@@ -844,9 +844,9 @@ if (<span class="kw">require</span>(topicmodels)) {
 ## 
 ##     dtm2ldaformat, ldaformat2dtm
 ##      Lenihan FF Bruton FG Burton LAB Morgan SF Cowen FF Kenny FG ODonnell FG Gilmore LAB Higgins LAB Quinn LAB Gormley Green Ryan Green Cuffe Green OCaolain SF
-## [1,]         10        11         19        15       18       17          13           2           9         8             9         14           5           7
-## [2,]          4         3          1        20       12        8           8          16          19        20             6          6          16          20
-## [3,]          6         8         18         8        8       14           5           5          16        16             4          5          14           8</code></pre></div>
+## [1,]         11        19         10        17        3       14           7           9           5        20            16          5          12           4
+## [2,]          1        12          6         8       18       20          16          13          14         2            18         12          18          15
+## [3,]          2        16          2        20       20       16          12          20          13        13            11         16          16          16</code></pre></div>
 </div>
 </div>
 


### PR DESCRIPTION
Fix warning messages on corpus_segment/char_segment when delimiter is supplied but what = "tokens" or "sentences". 