### PR TITLE
Issue 684

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 * Fixed bug #707 where `ntype.dfm()` produced an incorrect result.
 * Fixed bug #706 where `textstat_lexdiv()` was returning incorrect results for single-document dfm objects.
 * Improved the robustness of `corpus_reshape()`.
+* `print`, and `head`, and `tail` methods for `dfm` are more robust (#684).
 
 ## Changes since v0.9.9-24
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -85,15 +85,15 @@ qatd_cpp_chars_remove <- function(input_, char_remove) {
     .Call('quanteda_qatd_cpp_chars_remove', PACKAGE = 'quanteda', input_, char_remove)
 }
 
-wordfishcpp <- function(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor) {
-    .Call('quanteda_wordfishcpp', PACKAGE = 'quanteda', wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor)
-}
-
 wordfishcpp_dense <- function(wfm, dir, priors, tol, disp, dispfloor, abs_err) {
     .Call('quanteda_wordfishcpp_dense', PACKAGE = 'quanteda', wfm, dir, priors, tol, disp, dispfloor, abs_err)
 }
 
 wordfishcpp_mt <- function(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_sparse, residual_floor) {
     .Call('quanteda_wordfishcpp_mt', PACKAGE = 'quanteda', wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_sparse, residual_floor)
+}
+
+wordfishcpp <- function(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor) {
+    .Call('quanteda_wordfishcpp', PACKAGE = 'quanteda', wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor)
 }
 

--- a/R/dfm-print.R
+++ b/R/dfm-print.R
@@ -6,10 +6,12 @@
 NULL
 
 #' @param x the dfm to be printed
-#' @param show.values print the dfm as a matrix or array (if resampled).
+#' @param show.values print the dfm values; if called explicitly this will print
+#'   all values, overriding \code{ndoc} and \code{nfeature}.
 #' @param show.settings print the settings used to create the dfm.  See 
 #'   \link{settings}.
-#' @param show.summary print a brief summary indicating the number of documents and features
+#' @param show.summary print a brief summary indicating the number of documents
+#'   and features
 #' @param ndoc max number of documents to print
 #' @param nfeature max number of features to print
 #' @param ... further arguments passed to or from other methods
@@ -18,32 +20,48 @@ NULL
 #' @keywords dfm
 setMethod("print", signature(x = "dfm"), 
           function(x, show.values = FALSE, show.settings = FALSE, show.summary = TRUE, ndoc = 20L, nfeature = 20L, ...) {
-              if (length(x) > 0) {
-                  if (show.summary) {
-                      cat("Document-feature matrix of: ",
-                          format(ndoc(x), , big.mark=","), " document",
-                          ifelse(ndoc(x)>1 | ndoc(x)==0, "s, ", ", "),
-                          format(nfeature(x), big.mark=","), " feature",
-                          ifelse(nfeature(x)>1 | nfeature(x)==0, "s", ""),
-                          ifelse(is.resampled(x), paste(", ", nresample(x), " resamples", sep=""), ""),
-                          " (", format(sparsity(x)*100, digits = 3),
-                          "% sparse).\n", sep="")
-                  }
-                  if (show.settings) {
-                      cat("Settings: TO BE IMPLEMENTED.")
-                  }
-                  if (show.values | (nrow(x) <= ndoc & ncol(x) <= nfeature)) {
-                      if (is(x, "sparseMatrix"))
-                          Matrix::printSpMatrix2(x[1:min(ndoc, ndoc(x)), 1:min(nfeature, nfeature(x))], 
-                                             col.names=TRUE, zero.print=0, ...)
-                      else if (is(x, "denseMatrix")) {
-                          getMethod("show", "denseMatrix")(x, ...)
-                      } else {
-                          print(as.matrix(x))
-                      }
-                  }
-              } else{
+              
+              if (!length(x)) {
                   print(NULL)
+                  return()
+              } 
+
+              if (show.summary) {
+                  cat("Document-feature matrix of: ",
+                      format(ndoc(x), , big.mark=","), " document",
+                      ifelse(ndoc(x)>1 | ndoc(x)==0, "s, ", ", "),
+                      format(nfeature(x), big.mark=","), " feature",
+                      ifelse(nfeature(x)>1 | nfeature(x)==0, "s", ""),
+                      ifelse(is.resampled(x), paste(", ", nresample(x), " resamples", sep=""), ""),
+                      " (", format(sparsity(x)*100, digits = 3),
+                      "% sparse).\n", sep="")
+              }
+              
+              if (show.settings) {
+                  cat("Settings: TO BE IMPLEMENTED.")
+              }
+              
+              if (show.values == TRUE) {
+                  ndoc <- nrow(x)
+                  nfeature <- ncol(x)
+              } else if (missing(show.values)) {
+                  if (nrow(x) <= ndoc & ncol(x) <= nfeature) {
+                      ndoc <- nrow(x)
+                      nfeature <- ncol(x)
+                      show.values <- TRUE
+                  } else {
+                      show.values <- FALSE
+                  }
+              }
+              
+              if (show.values)
+                  if (is(x, "sparseMatrix"))
+                      Matrix::printSpMatrix2(x[1:ndoc, 1:nfeature], 
+                                             col.names=TRUE, zero.print=0, ...)
+              else if (is(x, "denseMatrix")) {
+                  getMethod("show", "denseMatrix")(x[1:ndoc, 1:nfeature], ...)
+              } else {
+                  print(as.matrix(x[1:ndoc, 1:nfeature]))
               }
           })
 

--- a/man/print.dfm.Rd
+++ b/man/print.dfm.Rd
@@ -22,12 +22,14 @@
 \arguments{
 \item{x}{the dfm to be printed}
 
-\item{show.values}{print the dfm as a matrix or array (if resampled).}
+\item{show.values}{print the dfm values; if called explicitly this will print
+all values, overriding \code{ndoc} and \code{nfeature}.}
 
 \item{show.settings}{print the settings used to create the dfm.  See 
 \link{settings}.}
 
-\item{show.summary}{print a brief summary indicating the number of documents and features}
+\item{show.summary}{print a brief summary indicating the number of documents
+and features}
 
 \item{ndoc}{max number of documents to print}
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -295,25 +295,6 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// wordfishcpp
-Rcpp::List wordfishcpp(arma::sp_mat& wfm, IntegerVector& dirvec, NumericVector& priorvec, NumericVector& tolvec, IntegerVector& disptype, NumericVector& dispmin, bool ABS, bool svd_on, double residual_floor);
-RcppExport SEXP quanteda_wordfishcpp(SEXP wfmSEXP, SEXP dirvecSEXP, SEXP priorvecSEXP, SEXP tolvecSEXP, SEXP disptypeSEXP, SEXP dispminSEXP, SEXP ABSSEXP, SEXP svd_onSEXP, SEXP residual_floorSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< arma::sp_mat& >::type wfm(wfmSEXP);
-    Rcpp::traits::input_parameter< IntegerVector& >::type dirvec(dirvecSEXP);
-    Rcpp::traits::input_parameter< NumericVector& >::type priorvec(priorvecSEXP);
-    Rcpp::traits::input_parameter< NumericVector& >::type tolvec(tolvecSEXP);
-    Rcpp::traits::input_parameter< IntegerVector& >::type disptype(disptypeSEXP);
-    Rcpp::traits::input_parameter< NumericVector& >::type dispmin(dispminSEXP);
-    Rcpp::traits::input_parameter< bool >::type ABS(ABSSEXP);
-    Rcpp::traits::input_parameter< bool >::type svd_on(svd_onSEXP);
-    Rcpp::traits::input_parameter< double >::type residual_floor(residual_floorSEXP);
-    rcpp_result_gen = Rcpp::wrap(wordfishcpp(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor));
-    return rcpp_result_gen;
-END_RCPP
-}
 // wordfishcpp_dense
 Rcpp::List wordfishcpp_dense(SEXP wfm, SEXP dir, SEXP priors, SEXP tol, SEXP disp, SEXP dispfloor, bool abs_err);
 RcppExport SEXP quanteda_wordfishcpp_dense(SEXP wfmSEXP, SEXP dirSEXP, SEXP priorsSEXP, SEXP tolSEXP, SEXP dispSEXP, SEXP dispfloorSEXP, SEXP abs_errSEXP) {
@@ -347,6 +328,25 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< bool >::type svd_sparse(svd_sparseSEXP);
     Rcpp::traits::input_parameter< double >::type residual_floor(residual_floorSEXP);
     rcpp_result_gen = Rcpp::wrap(wordfishcpp_mt(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_sparse, residual_floor));
+    return rcpp_result_gen;
+END_RCPP
+}
+// wordfishcpp
+Rcpp::List wordfishcpp(arma::sp_mat& wfm, IntegerVector& dirvec, NumericVector& priorvec, NumericVector& tolvec, IntegerVector& disptype, NumericVector& dispmin, bool ABS, bool svd_on, double residual_floor);
+RcppExport SEXP quanteda_wordfishcpp(SEXP wfmSEXP, SEXP dirvecSEXP, SEXP priorvecSEXP, SEXP tolvecSEXP, SEXP disptypeSEXP, SEXP dispminSEXP, SEXP ABSSEXP, SEXP svd_onSEXP, SEXP residual_floorSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< arma::sp_mat& >::type wfm(wfmSEXP);
+    Rcpp::traits::input_parameter< IntegerVector& >::type dirvec(dirvecSEXP);
+    Rcpp::traits::input_parameter< NumericVector& >::type priorvec(priorvecSEXP);
+    Rcpp::traits::input_parameter< NumericVector& >::type tolvec(tolvecSEXP);
+    Rcpp::traits::input_parameter< IntegerVector& >::type disptype(disptypeSEXP);
+    Rcpp::traits::input_parameter< NumericVector& >::type dispmin(dispminSEXP);
+    Rcpp::traits::input_parameter< bool >::type ABS(ABSSEXP);
+    Rcpp::traits::input_parameter< bool >::type svd_on(svd_onSEXP);
+    Rcpp::traits::input_parameter< double >::type residual_floor(residual_floorSEXP);
+    rcpp_result_gen = Rcpp::wrap(wordfishcpp(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/tests/testthat/test-dfm.R
+++ b/tests/testthat/test-dfm.R
@@ -419,3 +419,31 @@ test_that("dfm's document counts in verbose message is correct", {
                    'kept 2 features and 4 documents')
 })
 
+test_that("dfm print works with options as expected", {
+    tmp <- dfm(data_corpus_irishbudget2010)
+    expect_output(
+        head(tmp),
+        "Document-feature matrix of: 14 documents, 5,058 features.*\\(showing first 6 documents and first 6 features\\)"
+    )
+    expect_output(
+        head(tmp[1:5, 1:5]),
+        "Document-feature matrix of: 5 documents, 5 features.*\\(showing first 5 documents and first 5 features\\)"
+    )
+    expect_output(
+        print(tmp[1:5, 1:5]),
+        "Document-feature matrix of: 5 documents, 5 features.*5 x 5 sparse Matrix"
+    )
+    expect_output(
+        print(tmp[1:5, 1:5], show.values = FALSE),
+        "^Document-feature matrix of: 5 documents, 5 features \\(28% sparse\\)\\.$"
+    )
+    expect_output(
+        print(tmp[1:3, 1:3], ndoc = 2, nfeature = 2, show.values = TRUE),
+        "^Document-feature matrix of: 3 documents, 3 features.*3 x 3 sparse Matrix"
+    )
+    expect_output(
+        print(tmp[1:5, 1:5], show.summary = FALSE),
+        "^5 x 5 sparse Matrix"
+    )
+})
+


### PR DESCRIPTION
Fixes #684 and makes `print.dfm()`, `head.dfm()`, and `tail.dfm()` more robust.