### PR TITLE
Dev readtext

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 * Conversion of a dfm to an stm object now passes docvars through in the `$meta` of the return object.
 * New `dfm_group(x, groups = )` command, a convenience wrapper around `dfm.dfm(x, groups = )` (#725).
 * Methods for extending quanteda functions to readtext objects updated to match CRAN release of readtext package.
+* Corpus constructor methods for data.frame objects now conform to the "text interchange format" for corpus data.frames, automatically recognizing `doc_id` and `text` fields, which also provides interoperability with the **readtext** package.  corpus construction methods are now more explicitly tailored to input object classes.
 
 ### Bug fixes and stability enhancements
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -85,15 +85,15 @@ qatd_cpp_chars_remove <- function(input_, char_remove) {
     .Call('quanteda_qatd_cpp_chars_remove', PACKAGE = 'quanteda', input_, char_remove)
 }
 
-wordfishcpp <- function(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor) {
-    .Call('quanteda_wordfishcpp', PACKAGE = 'quanteda', wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor)
-}
-
 wordfishcpp_dense <- function(wfm, dir, priors, tol, disp, dispfloor, abs_err) {
     .Call('quanteda_wordfishcpp_dense', PACKAGE = 'quanteda', wfm, dir, priors, tol, disp, dispfloor, abs_err)
 }
 
 wordfishcpp_mt <- function(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_sparse, residual_floor) {
     .Call('quanteda_wordfishcpp_mt', PACKAGE = 'quanteda', wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_sparse, residual_floor)
+}
+
+wordfishcpp <- function(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor) {
+    .Call('quanteda_wordfishcpp', PACKAGE = 'quanteda', wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor)
 }
 

--- a/man/corpus.Rd
+++ b/man/corpus.Rd
@@ -2,13 +2,28 @@
 % Please edit documentation in R/corpus.R
 \name{corpus}
 \alias{corpus}
+\alias{corpus.character}
+\alias{corpus.data.frame}
+\alias{corpus.kwic}
+\alias{corpus.Corpus}
 \title{construct a corpus object}
 \usage{
-corpus(x, docnames = NULL, docvars = NULL, text_field = "text",
+corpus(x, ...)
+
+\method{corpus}{character}(x, docnames = NULL, docvars = NULL,
   metacorpus = NULL, compress = FALSE, ...)
+
+\method{corpus}{data.frame}(x, docid_field = "doc_id", text_field = "text",
+  metacorpus = NULL, compress = FALSE, ...)
+
+\method{corpus}{kwic}(x, ...)
+
+\method{corpus}{Corpus}(x, metacorpus = NULL, compress = FALSE, ...)
 }
 \arguments{
 \item{x}{a valid corpus source object}
+
+\item{...}{not used directly}
 
 \item{docnames}{Names to be assigned to the texts.  Defaults to the names of 
 the character vector (if any); \code{doc_id} for a data.frame; the document
@@ -18,14 +33,9 @@ length to the number of documents.  If none of these are round, then
 
 \item{docvars}{A data frame of attributes that is associated with each text.}
 
-\item{text_field}{the character name or numeric index of the source \code{data.frame}
-indicating the variable to be read in as text, which must be a character vector.
-All other variables in the data.frame will be imported as docvars.  This argument 
-is only used for \code{data.frame} objects (including those created by \pkg{readtext}).}
-
-\item{metacorpus}{a named list containing additional (character) information to be added to the
-corpus as corpus-level metadata.  Special fields recognized in the \code{\link{summary.corpus}}
-are: 
+\item{metacorpus}{a named list containing additional (character) information
+  to be added to the corpus as corpus-level metadata.  Special fields
+  recognized in the \code{\link{summary.corpus}} are:
 \itemize{
 \item{\code{source }}{a description of the source of the texts, used for 
   referencing;}
@@ -34,16 +44,25 @@ are:
   to do lists, etc.}
 }}
 
-\item{compress}{logical; if \code{TRUE}, compress the texts in memory using gzip compression.
-This significantly reduces the size of the corpus in memory, but will slow down operations that
-require the texts to be extracted.}
+\item{compress}{logical; if \code{TRUE}, compress the texts in memory using
+gzip compression. This significantly reduces the size of the corpus in
+memory, but will slow down operations that require the texts to be
+extracted.}
 
-\item{...}{not used directly}
+\item{docid_field}{name of the data.frame variable containing the document
+identifier; defaults to \code{doc_id} but if this is not found, will use
+the row.names of the data.frame if these are assigned}
+
+\item{text_field}{the character name or numeric index of the source
+\code{data.frame} indicating the variable to be read in as text, which must
+be a character vector. All other variables in the data.frame will be
+imported as docvars.  This argument is only used for \code{data.frame}
+objects (including those created by \pkg{readtext}).}
 }
 \value{
-A \link{corpus-class} class object containing the original texts, document-level 
-  variables, document-level metadata, corpus-level metadata, and default 
-  settings for subsequent processing of the corpus.
+A \link{corpus-class} class object containing the original texts,
+  document-level variables, document-level metadata, corpus-level metadata,
+  and default settings for subsequent processing of the corpus.
 }
 \description{
 Creates a corpus object from available sources.  The currently available  
@@ -51,12 +70,11 @@ sources are:
 \itemize{ 
 \item a \link{character} vector, consisting of one document per element; if 
   the elements are named, these names will be used as document names.
-\item a readtext object, from the \pkg{readtext} package 
-  (which is a specially constructed data.frame)
-\item a \link{data.frame}, whose default variable containing the document is 
-  character vector named \code{text}, although this can be set to any other
-  variable name using the \code{text_field} argument.  Other variables are 
-  imported as document-level meta-data.
+\item a \link{data.frame}, whose default document id is a variable identified
+by \code{docid_field}; the text of the document is a variable identified by
+\code{textid_field}; and other variables are imported as document-level
+meta-data.  This matches the format of data.frames constructed by the the
+\pkg{readtext} package.
 \item a \link{kwic} object constructed by \code{\link{kwic}}.
 \item a \pkg{tm} \link[tm]{VCorpus} or \link[tm]{SimpleCorpus} class  object, 
   with the fixed metadata 
@@ -82,13 +100,12 @@ The texts and document variables of corpus objects can also be
   For details, see \link{corpus-class}.
 }
 \section{A warning on accessing corpus elements}{
-
-  A corpus currently 
-  consists of an S3 specially classed list of elements, but \strong{you should not 
+ A corpus currently consists
+  of an S3 specially classed list of elements, but \strong{you should not 
   access these elements directly}. Use the extractor and replacement 
-  functions instead, or else your code is not only going to be uglier, but
-  also likely to break should the internal structure of a corpus object
-  change (as it inevitably will as we continue to develop the package,
+  functions instead, or else your code is not only going to be uglier, but 
+  also likely to break should the internal structure of a corpus object 
+  change (as it inevitably will as we continue to develop the package, 
   including moving corpus objects to the S4 class system).
 }
 

--- a/man/corpus.Rd
+++ b/man/corpus.Rd
@@ -10,8 +10,11 @@ corpus(x, docnames = NULL, docvars = NULL, text_field = "text",
 \arguments{
 \item{x}{a valid corpus source object}
 
-\item{docnames}{Names to be assigned to the texts, defaults to the names of 
-the character vector (if any), otherwise assigns "text1", "text2", etc.}
+\item{docnames}{Names to be assigned to the texts.  Defaults to the names of 
+the character vector (if any); \code{doc_id} for a data.frame; the document
+names in a \pkg{tm} corpus; or a vector of user-supplied labels equal in 
+length to the number of documents.  If none of these are round, then 
+"text1", "text2", etc. are assigned automatically.}
 
 \item{docvars}{A data frame of attributes that is associated with each text.}
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -295,25 +295,6 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// wordfishcpp
-Rcpp::List wordfishcpp(arma::sp_mat& wfm, IntegerVector& dirvec, NumericVector& priorvec, NumericVector& tolvec, IntegerVector& disptype, NumericVector& dispmin, bool ABS, bool svd_on, double residual_floor);
-RcppExport SEXP quanteda_wordfishcpp(SEXP wfmSEXP, SEXP dirvecSEXP, SEXP priorvecSEXP, SEXP tolvecSEXP, SEXP disptypeSEXP, SEXP dispminSEXP, SEXP ABSSEXP, SEXP svd_onSEXP, SEXP residual_floorSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< arma::sp_mat& >::type wfm(wfmSEXP);
-    Rcpp::traits::input_parameter< IntegerVector& >::type dirvec(dirvecSEXP);
-    Rcpp::traits::input_parameter< NumericVector& >::type priorvec(priorvecSEXP);
-    Rcpp::traits::input_parameter< NumericVector& >::type tolvec(tolvecSEXP);
-    Rcpp::traits::input_parameter< IntegerVector& >::type disptype(disptypeSEXP);
-    Rcpp::traits::input_parameter< NumericVector& >::type dispmin(dispminSEXP);
-    Rcpp::traits::input_parameter< bool >::type ABS(ABSSEXP);
-    Rcpp::traits::input_parameter< bool >::type svd_on(svd_onSEXP);
-    Rcpp::traits::input_parameter< double >::type residual_floor(residual_floorSEXP);
-    rcpp_result_gen = Rcpp::wrap(wordfishcpp(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor));
-    return rcpp_result_gen;
-END_RCPP
-}
 // wordfishcpp_dense
 Rcpp::List wordfishcpp_dense(SEXP wfm, SEXP dir, SEXP priors, SEXP tol, SEXP disp, SEXP dispfloor, bool abs_err);
 RcppExport SEXP quanteda_wordfishcpp_dense(SEXP wfmSEXP, SEXP dirSEXP, SEXP priorsSEXP, SEXP tolSEXP, SEXP dispSEXP, SEXP dispfloorSEXP, SEXP abs_errSEXP) {
@@ -347,6 +328,25 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< bool >::type svd_sparse(svd_sparseSEXP);
     Rcpp::traits::input_parameter< double >::type residual_floor(residual_floorSEXP);
     rcpp_result_gen = Rcpp::wrap(wordfishcpp_mt(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_sparse, residual_floor));
+    return rcpp_result_gen;
+END_RCPP
+}
+// wordfishcpp
+Rcpp::List wordfishcpp(arma::sp_mat& wfm, IntegerVector& dirvec, NumericVector& priorvec, NumericVector& tolvec, IntegerVector& disptype, NumericVector& dispmin, bool ABS, bool svd_on, double residual_floor);
+RcppExport SEXP quanteda_wordfishcpp(SEXP wfmSEXP, SEXP dirvecSEXP, SEXP priorvecSEXP, SEXP tolvecSEXP, SEXP disptypeSEXP, SEXP dispminSEXP, SEXP ABSSEXP, SEXP svd_onSEXP, SEXP residual_floorSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< arma::sp_mat& >::type wfm(wfmSEXP);
+    Rcpp::traits::input_parameter< IntegerVector& >::type dirvec(dirvecSEXP);
+    Rcpp::traits::input_parameter< NumericVector& >::type priorvec(priorvecSEXP);
+    Rcpp::traits::input_parameter< NumericVector& >::type tolvec(tolvecSEXP);
+    Rcpp::traits::input_parameter< IntegerVector& >::type disptype(disptypeSEXP);
+    Rcpp::traits::input_parameter< NumericVector& >::type dispmin(dispminSEXP);
+    Rcpp::traits::input_parameter< bool >::type ABS(ABSSEXP);
+    Rcpp::traits::input_parameter< bool >::type svd_on(svd_onSEXP);
+    Rcpp::traits::input_parameter< double >::type residual_floor(residual_floorSEXP);
+    rcpp_result_gen = Rcpp::wrap(wordfishcpp(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/tests/testthat/test-corpus.R
+++ b/tests/testthat/test-corpus.R
@@ -116,15 +116,15 @@ test_that("test corpus constructors works for data.frame", {
     expect_equal(corpus(mydf, text_field = "some_text"),
                  corpus(mydf3))
     
-    expect_equal(
-        docnames(corpus(mydf3, docnames = paste0("d", 1:6))),
-        c("d1", "d2", "d3", "d4", "d5", "d6")
+    expect_error(
+        corpus(mydf3, docid_field = paste0("d", 1:6)),
+        "docid_field must refer to a single column"
     )
     
-    expect_error(
-        corpus(mydf3, docnames = paste0("d", 1:5)),
-        "user-supplied docnames must be the same as the number of documents"
-    )
+    # expect_error(
+    #     corpus(mydf3, docnames = paste0("d", 1:5)),
+    #     "user-supplied docnames must be the same as the number of documents"
+    # )
     
     expect_equal(corpus(mydf, text_field = "some_text"),
                  corpus(mydf, text_field = 3))

--- a/tests/testthat/test-corpus.R
+++ b/tests/testthat/test-corpus.R
@@ -110,6 +110,22 @@ test_that("test corpus constructors works for data.frame", {
     expect_equal(corpus(mydf, text_field = "some_text"),
                  corpus(mydf2))
     
+    mydf3 <- mydf2
+    mydf3$doc_id <- row.names(mydf3)
+    row.names(mydf3) <- NULL
+    expect_equal(corpus(mydf, text_field = "some_text"),
+                 corpus(mydf3))
+    
+    expect_equal(
+        docnames(corpus(mydf3, docnames = paste0("d", 1:6))),
+        c("d1", "d2", "d3", "d4", "d5", "d6")
+    )
+    
+    expect_error(
+        corpus(mydf3, docnames = paste0("d", 1:5)),
+        "user-supplied docnames must be the same as the number of documents"
+    )
+    
     expect_equal(corpus(mydf, text_field = "some_text"),
                  corpus(mydf, text_field = 3))
     


### PR DESCRIPTION
Update methods relating to the **readtext** package, and corpus constructors from data.frame objects.

- adds compliance with the TIF corpus/data.frame format, including the **readtext** format which is now TIF-compliant
- Differentiate the argument signature for different corpus constructor functions
- Expose the different methods for corpus.*()
- Make default values for corpus.data.frame appropriate to that method, which covers TIF data.frames including readtext objects
- updates tests for the above