### PR TITLE
LIWC robustness additions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,7 @@
 ### Bug fixes and stability enhancements
 
 *  For `sequences()`: Corrected the word matching, and lambda and sigma calculation methods for `unigram subtuples` algorithm in `sequences_mt.cpp`, and consequently the p-values on the bigrams are correct. 
+*  LIWC-formatted dictionary import now robust to assignment to term assignment to missing categories.
 
 
 ## Changes since v0.9.9-50

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -2,102 +2,102 @@
 # Generator token: 10BE3573-1514-4C36-9D1C-5A225CD40393
 
 cacpp <- function(objm, threads, residual_floor) {
-    .Call(quanteda_cacpp, objm, threads, residual_floor)
+    .Call('quanteda_cacpp', PACKAGE = 'quanteda', objm, threads, residual_floor)
 }
 
 qatd_ManhattanPara_cpp <- function(A, margin = 1L) {
-    .Call(quanteda_qatd_ManhattanPara_cpp, A, margin)
+    .Call('quanteda_qatd_ManhattanPara_cpp', PACKAGE = 'quanteda', A, margin)
 }
 
 qatd_ManhattanPara_cpp2 <- function(A, B, margin = 1L) {
-    .Call(quanteda_qatd_ManhattanPara_cpp2, A, B, margin)
+    .Call('quanteda_qatd_ManhattanPara_cpp2', PACKAGE = 'quanteda', A, B, margin)
 }
 
 qatd_MaximumPara_cpp <- function(A, margin = 1L) {
-    .Call(quanteda_qatd_MaximumPara_cpp, A, margin)
+    .Call('quanteda_qatd_MaximumPara_cpp', PACKAGE = 'quanteda', A, margin)
 }
 
 qatd_MaximumPara_cpp2 <- function(A, B, margin = 1L) {
-    .Call(quanteda_qatd_MaximumPara_cpp2, A, B, margin)
+    .Call('quanteda_qatd_MaximumPara_cpp2', PACKAGE = 'quanteda', A, B, margin)
 }
 
 qatd_CanberraPara_cpp <- function(A, margin = 1L) {
-    .Call(quanteda_qatd_CanberraPara_cpp, A, margin)
+    .Call('quanteda_qatd_CanberraPara_cpp', PACKAGE = 'quanteda', A, margin)
 }
 
 qatd_CanberraPara_cpp2 <- function(A, B, margin = 1L) {
-    .Call(quanteda_qatd_CanberraPara_cpp2, A, B, margin)
+    .Call('quanteda_qatd_CanberraPara_cpp2', PACKAGE = 'quanteda', A, B, margin)
 }
 
 qatd_MinkowskiPara_cpp <- function(A, margin = 1L, p = 2) {
-    .Call(quanteda_qatd_MinkowskiPara_cpp, A, margin, p)
+    .Call('quanteda_qatd_MinkowskiPara_cpp', PACKAGE = 'quanteda', A, margin, p)
 }
 
 qatd_MinkowskiPara_cpp2 <- function(A, B, margin = 1L, p = 2) {
-    .Call(quanteda_qatd_MinkowskiPara_cpp2, A, B, margin, p)
+    .Call('quanteda_qatd_MinkowskiPara_cpp2', PACKAGE = 'quanteda', A, B, margin, p)
 }
 
 qatd_cpp_fcm <- function(texts_, n_types, count, window, weights, ordered, tri, nvec) {
-    .Call(quanteda_qatd_cpp_fcm, texts_, n_types, count, window, weights, ordered, tri, nvec)
+    .Call('quanteda_qatd_cpp_fcm', PACKAGE = 'quanteda', texts_, n_types, count, window, weights, ordered, tri, nvec)
 }
 
 qatd_cpp_sequences <- function(texts_, types_, count_min, len_min, len_max, method, nested) {
-    .Call(quanteda_qatd_cpp_sequences, texts_, types_, count_min, len_min, len_max, method, nested)
+    .Call('quanteda_qatd_cpp_sequences', PACKAGE = 'quanteda', texts_, types_, count_min, len_min, len_max, method, nested)
 }
 
 qatd_cpp_sequences_old <- function(texts_, words_, types_, count_min, len_max, nested, ordered = FALSE) {
-    .Call(quanteda_qatd_cpp_sequences_old, texts_, words_, types_, count_min, len_max, nested, ordered)
+    .Call('quanteda_qatd_cpp_sequences_old', PACKAGE = 'quanteda', texts_, words_, types_, count_min, len_max, nested, ordered)
 }
 
 qatd_cpp_tokens_compound <- function(texts_, comps_, types_, delim_, join) {
-    .Call(quanteda_qatd_cpp_tokens_compound, texts_, comps_, types_, delim_, join)
+    .Call('quanteda_qatd_cpp_tokens_compound', PACKAGE = 'quanteda', texts_, comps_, types_, delim_, join)
 }
 
 qatd_cpp_tokens_detect <- function(texts_, words_) {
-    .Call(quanteda_qatd_cpp_tokens_detect, texts_, words_)
+    .Call('quanteda_qatd_cpp_tokens_detect', PACKAGE = 'quanteda', texts_, words_)
 }
 
 qatd_cpp_kwic <- function(texts_, types_, words_, window) {
-    .Call(quanteda_qatd_cpp_kwic, texts_, types_, words_, window)
+    .Call('quanteda_qatd_cpp_kwic', PACKAGE = 'quanteda', texts_, types_, words_, window)
 }
 
 qatd_cpp_tokens_lookup <- function(texts_, types_, keys_, ids_, overlap) {
-    .Call(quanteda_qatd_cpp_tokens_lookup, texts_, types_, keys_, ids_, overlap)
+    .Call('quanteda_qatd_cpp_tokens_lookup', PACKAGE = 'quanteda', texts_, types_, keys_, ids_, overlap)
 }
 
 qatd_cpp_tokens_match <- function(texts_, types_, words_, ids_, overlap) {
-    .Call(quanteda_qatd_cpp_tokens_match, texts_, types_, words_, ids_, overlap)
+    .Call('quanteda_qatd_cpp_tokens_match', PACKAGE = 'quanteda', texts_, types_, words_, ids_, overlap)
 }
 
 qatd_cpp_tokens_ngrams <- function(texts_, types_, delim_, ns_, skips_) {
-    .Call(quanteda_qatd_cpp_tokens_ngrams, texts_, types_, delim_, ns_, skips_)
+    .Call('quanteda_qatd_cpp_tokens_ngrams', PACKAGE = 'quanteda', texts_, types_, delim_, ns_, skips_)
 }
 
 qatd_cpp_tokens_recompile <- function(texts_, types_) {
-    .Call(quanteda_qatd_cpp_tokens_recompile, texts_, types_)
+    .Call('quanteda_qatd_cpp_tokens_recompile', PACKAGE = 'quanteda', texts_, types_)
 }
 
 qatd_cpp_tokens_replace <- function(texts_, types_, words_, ids_) {
-    .Call(quanteda_qatd_cpp_tokens_replace, texts_, types_, words_, ids_)
+    .Call('quanteda_qatd_cpp_tokens_replace', PACKAGE = 'quanteda', texts_, types_, words_, ids_)
 }
 
 qatd_cpp_tokens_select <- function(texts_, types_, words_, mode, padding) {
-    .Call(quanteda_qatd_cpp_tokens_select, texts_, types_, words_, mode, padding)
+    .Call('quanteda_qatd_cpp_tokens_select', PACKAGE = 'quanteda', texts_, types_, words_, mode, padding)
 }
 
 qatd_cpp_chars_remove <- function(input_, char_remove) {
-    .Call(quanteda_qatd_cpp_chars_remove, input_, char_remove)
+    .Call('quanteda_qatd_cpp_chars_remove', PACKAGE = 'quanteda', input_, char_remove)
 }
 
 wordfishcpp <- function(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor) {
-    .Call(quanteda_wordfishcpp, wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor)
+    .Call('quanteda_wordfishcpp', PACKAGE = 'quanteda', wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor)
 }
 
 wordfishcpp_dense <- function(wfm, dir, priors, tol, disp, dispfloor, abs_err) {
-    .Call(quanteda_wordfishcpp_dense, wfm, dir, priors, tol, disp, dispfloor, abs_err)
+    .Call('quanteda_wordfishcpp_dense', PACKAGE = 'quanteda', wfm, dir, priors, tol, disp, dispfloor, abs_err)
 }
 
 wordfishcpp_mt <- function(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_sparse, residual_floor) {
-    .Call(quanteda_wordfishcpp_mt, wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_sparse, residual_floor)
+    .Call('quanteda_wordfishcpp_mt', PACKAGE = 'quanteda', wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_sparse, residual_floor)
 }
 

--- a/R/dictionaries-liwc_old.R
+++ b/R/dictionaries-liwc_old.R
@@ -73,7 +73,8 @@ read_dict_liwc_old <- function(path, encoding = "auto", toLower = FALSE) {
     # remove spaces before and after
     catlist <- stri_trim_both(catlist)
     
-    catlist <- strsplit(catlist, "\t")
+    catlist <- strsplit(catlist, "\\s")
+    catlist <- lapply(catlist, function(y) y[y != ""])
     catlist <- as.data.frame(do.call(rbind, lapply(catlist, '[', 1:max(sapply(catlist, length)))), stringsAsFactors = FALSE)
     suppressWarnings(catlist[, 2:ncol(catlist)] <- sapply(catlist[, 2:ncol(catlist)], as.integer))
     names(catlist)[1] <- "category"
@@ -101,7 +102,11 @@ read_dict_liwc_old <- function(path, encoding = "auto", toLower = FALSE) {
     
     for (ind in seq_along(terms)) {
         for(num in as.numeric(terms[[ind]])){
-            thisCat <- guide$catName[which(guide$catNum==num)]
+            tmpIndex <- which(guide$catNum == num)
+            if (!length(tmpIndex))
+                stop("Dictionary ", path, "\n  refers to undefined category ", num,
+                     " for term \"", names(terms[ind]), "\"", call. = FALSE)
+            thisCat <- guide$catName[tmpIndex]
             thisTerm <- names(terms[ind])
             dictionary[[thisCat]] <- append(dictionary[[thisCat]], thisTerm)
         }

--- a/R/dictionaries-liwc_old.R
+++ b/R/dictionaries-liwc_old.R
@@ -111,5 +111,12 @@ read_dict_liwc_old <- function(path, encoding = "auto", toLower = FALSE) {
             dictionary[[thisCat]] <- append(dictionary[[thisCat]], thisTerm)
         }
     }
+    
+    # check if any keys are empty, and remove them if so
+    if (any(emptykeys <- sapply(dictionary, is.null))) {
+        message("note: removing empty keys: ", paste(names(emptykeys[which(emptykeys)]), collapse = ", "))
+        dictionary <- dictionary[-which(emptykeys)]
+    }
+    
     return(dictionary)
 }

--- a/tests/data/dictionaries/liwc_extracodes.dic
+++ b/tests/data/dictionaries/liwc_extracodes.dic
@@ -1,0 +1,25 @@
+%
+11	verb
+13	past
+121 whatever
+122	family
+123	friend
+124	humans
+125	affect
+126	posemo
+131	cogmech
+132	insight
+133	cause
+134	discrep
+135	tentat
+140 whatever2
+253	time
+464	filler
+%
+kin	121	122
+kind	<of>131/125	<of>135/126
+kinda	131	135
+light	140
+like	(02 134)125/464	(02 134)126	(02 134)126	253
+likeab*	125	126
+liked	11	13	125	126

--- a/tests/data/dictionaries/mary_doubleterm.dic
+++ b/tests/data/dictionaries/mary_doubleterm.dic
@@ -1,0 +1,11 @@
+%
+01	A_CATEGORY
+02	ANOTHER_CATEGORY
+%
+
+more	01
+lamb	01
+little	01
+little  02
+had	02
+mary	02

--- a/tests/data/dictionaries/mary_missingcat.dic
+++ b/tests/data/dictionaries/mary_missingcat.dic
@@ -1,0 +1,11 @@
+%
+01	A_CATEGORY
+02	ANOTHER_CATEGORY
+%
+
+more    01
+lamb    01
+little    01
+little    02    03
+had    02
+mary    02

--- a/tests/data/dictionaries/mary_multipletabs.dic
+++ b/tests/data/dictionaries/mary_multipletabs.dic
@@ -1,0 +1,10 @@
+%
+01	A_CATEGORY
+02	ANOTHER_CATEGORY
+%
+
+more    01
+lamb    01
+little        01    02
+had    02
+mary    02

--- a/tests/testthat/test-dictionaries.R
+++ b/tests/testthat/test-dictionaries.R
@@ -222,3 +222,28 @@ test_that("dictionary constructor works with LIWC format w/multiple tabs, spaces
     )
 })
 
+test_that("dictionary constructor works with LIWC format w/extra codes", {
+    expect_message(
+        dictionary(file = "../data/dictionaries/liwc_extracodes.dic"),
+        "note: 1 term ignored because contains unsupported <of> tag"
+    )
+    expect_message(
+        dictionary(file = "../data/dictionaries/liwc_extracodes.dic"),
+        "note: ignoring parenthetical expressions in lines:"
+    )
+    expect_message(
+        dictionary(file = "../data/dictionaries/liwc_extracodes.dic"),
+        "note: removing empty keys: friend, humans, insight, cause, discrep, filler"
+    )
+    d <- dictionary(file = "../data/dictionaries/liwc_extracodes.dic")
+    expect_equal(
+        length(d), 
+        10
+    )
+    expect_equal(
+        names(d), 
+        c("verb", "past", "whatever", "family", "affect", "posemo", "cogmech", "tentat", "whatever2", "time")
+    )
+})
+
+

--- a/tests/testthat/test-dictionaries.R
+++ b/tests/testthat/test-dictionaries.R
@@ -214,3 +214,11 @@ test_that("dictionary constructor errors as expected with LIWC format missing a 
     )
 })
 
+test_that("dictionary constructor works with LIWC format w/multiple tabs, spaces, etc", {
+    expect_equivalent(
+        dictionary(file = "../data/dictionaries/mary_multipletabs.dic"),
+        dictionary(list(A_CATEGORY = c("lamb", "little", "more"),
+                        ANOTHER_CATEGORY = c("had", "little", "mary")))
+    )
+})
+

--- a/tests/testthat/test-dictionaries.R
+++ b/tests/testthat/test-dictionaries.R
@@ -198,3 +198,19 @@ test_that("dictionary woks with the Yoshicoder format", {
     
 })    
 
+
+test_that("dictionary constructor works with LIWC format w/doubled terms", {
+    expect_equivalent(
+        dictionary(file = "../data/dictionaries/mary_doubleterm.dic"),
+        dictionary(list(A_CATEGORY = c("lamb", "little", "more"),
+                        ANOTHER_CATEGORY = c("had", "little", "mary")))
+    )
+})
+
+test_that("dictionary constructor errors as expected with LIWC format missing a category", {
+    expect_error(
+        dictionary(file = "../data/dictionaries/mary_missingcat.dic"),
+        "Dictionary.*refers to undefined category 3 for term \"little\"" 
+    )
+})
+


### PR DESCRIPTION
Adds robustness for reading improperly formatted LIWC files, and adds tests.

Still need to add tests for the 
- [x] parenthetical code issue, found in e.g. `LIWC2007_English080730.dic`
- [x] the `<or>` tags found in the same file

These exceptions are handled in e.g. https://github.com/kbenoit/quanteda/blob/master/R/dictionaries-liwc_old.R#L54-L61 but need tests.