### PR TITLE
Dev options

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -41,12 +41,12 @@ qatd_cpp_fcm <- function(texts_, n_types, count, window, weights, ordered, tri, 
     .Call(quanteda_qatd_cpp_fcm, texts_, n_types, count, window, weights, ordered, tri, nvec)
 }
 
-qatd_cpp_sequences <- function(texts_, types_, count_min, len_min, len_max, method, nested) {
-    .Call(quanteda_qatd_cpp_sequences, texts_, types_, count_min, len_min, len_max, method, nested)
-}
-
 qatd_cpp_sequences_old <- function(texts_, words_, types_, count_min, len_max, nested, ordered = FALSE) {
     .Call(quanteda_qatd_cpp_sequences_old, texts_, words_, types_, count_min, len_max, nested, ordered)
+}
+
+qatd_cpp_sequences <- function(texts_, types_, count_min, len_min, len_max, method, nested) {
+    .Call(quanteda_qatd_cpp_sequences, texts_, types_, count_min, len_min, len_max, method, nested)
 }
 
 qatd_cpp_tokens_compound <- function(texts_, comps_, types_, delim_, join) {
@@ -93,15 +93,15 @@ qatd_cpp_chars_remove <- function(input_, char_remove) {
     .Call(quanteda_qatd_cpp_chars_remove, input_, char_remove)
 }
 
-wordfishcpp <- function(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor) {
-    .Call(quanteda_wordfishcpp, wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor)
-}
-
 wordfishcpp_dense <- function(wfm, dir, priors, tol, disp, dispfloor, abs_err) {
     .Call(quanteda_wordfishcpp_dense, wfm, dir, priors, tol, disp, dispfloor, abs_err)
 }
 
 wordfishcpp_mt <- function(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_sparse, residual_floor) {
     .Call(quanteda_wordfishcpp_mt, wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_sparse, residual_floor)
+}
+
+wordfishcpp <- function(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor) {
+    .Call(quanteda_wordfishcpp, wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor)
 }
 

--- a/R/quanteda_options.R
+++ b/R/quanteda_options.R
@@ -8,7 +8,9 @@ QUANTEDA_OPTION_LIST <- list(quanteda_threads = max(1L, RcppParallel::defaultNum
 #' get or set package options for quanteda
 #' 
 #' Get or set global options affecting functions across \pkg{quatneda}.
-#' @param ... options to be set, as key-value pair, same as \code{\link{options}}
+#' @param ... options to be set, as key-value pair, same as \code{\link{options}}. 
+#'   This may be a list of valid key-value pairs, useful for setting a group of
+#'   options at once (see examples).
 #' @param reset logical; if \code{TRUE}, reset all \pkg{quanteda} options to their 
 #'   default values
 #' @param initialize logical; if \code{TRUE}, reset only the \pkg{quanteda} options 
@@ -37,16 +39,22 @@ QUANTEDA_OPTION_LIST <- list(quanteda_threads = max(1L, RcppParallel::defaultNum
 #' @export
 #' @importFrom RcppParallel setThreadOptions
 #' @examples
-#' quanteda_options()
+#' (qopts <- quanteda_options())
+#' \donttest{
 #' quanteda_options(verbose = TRUE)
 #' quanteda_options("verbose" = FALSE)
 #' quanteda_options("threads")
 #' quanteda_options(print_dfm_max_ndoc = 50L)
-#' \dontrun{
-#' quanteda_options(reset = TRUE) 
+#' # reset to defaults
+#' quanteda_options(reset = TRUE)
+#' # reset to saved values 
+#' quanteda_options(qopts)
 #' }
 quanteda_options <- function(..., reset = FALSE, initialize = FALSE) {
     args <- list(...)
+    
+    # if the ... is a list already, use that
+    if (length(args)==1 && is.list(args[[1]])) args <- args[[1]]
     
     if (initialize)
         return(quanteda_initialize())

--- a/man/quanteda_options.Rd
+++ b/man/quanteda_options.Rd
@@ -7,7 +7,9 @@
 quanteda_options(..., reset = FALSE, initialize = FALSE)
 }
 \arguments{
-\item{...}{options to be set, as key-value pair, same as \code{\link{options}}}
+\item{...}{options to be set, as key-value pair, same as \code{\link{options}}. 
+This may be a list of valid key-value pairs, useful for setting a group of
+options at once (see examples).}
 
 \item{reset}{logical; if \code{TRUE}, reset all \pkg{quanteda} options to their 
 default values}
@@ -42,12 +44,15 @@ Currently available options are:
 }
 }
 \examples{
-quanteda_options()
+(qopts <- quanteda_options())
+\donttest{
 quanteda_options(verbose = TRUE)
 quanteda_options("verbose" = FALSE)
 quanteda_options("threads")
 quanteda_options(print_dfm_max_ndoc = 50L)
-\dontrun{
-quanteda_options(reset = TRUE) 
+# reset to defaults
+quanteda_options(reset = TRUE)
+# reset to saved values 
+quanteda_options(qopts)
 }
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -139,23 +139,6 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// qatd_cpp_sequences
-DataFrame qatd_cpp_sequences(const List& texts_, const CharacterVector& types_, const unsigned int count_min, unsigned int len_min, unsigned int len_max, const String& method, bool nested);
-RcppExport SEXP quanteda_qatd_cpp_sequences(SEXP texts_SEXP, SEXP types_SEXP, SEXP count_minSEXP, SEXP len_minSEXP, SEXP len_maxSEXP, SEXP methodSEXP, SEXP nestedSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const List& >::type texts_(texts_SEXP);
-    Rcpp::traits::input_parameter< const CharacterVector& >::type types_(types_SEXP);
-    Rcpp::traits::input_parameter< const unsigned int >::type count_min(count_minSEXP);
-    Rcpp::traits::input_parameter< unsigned int >::type len_min(len_minSEXP);
-    Rcpp::traits::input_parameter< unsigned int >::type len_max(len_maxSEXP);
-    Rcpp::traits::input_parameter< const String& >::type method(methodSEXP);
-    Rcpp::traits::input_parameter< bool >::type nested(nestedSEXP);
-    rcpp_result_gen = Rcpp::wrap(qatd_cpp_sequences(texts_, types_, count_min, len_min, len_max, method, nested));
-    return rcpp_result_gen;
-END_RCPP
-}
 // qatd_cpp_sequences_old
 DataFrame qatd_cpp_sequences_old(const List& texts_, const IntegerVector& words_, const CharacterVector& types_, const unsigned int count_min, unsigned int len_max, bool nested, bool ordered);
 RcppExport SEXP quanteda_qatd_cpp_sequences_old(SEXP texts_SEXP, SEXP words_SEXP, SEXP types_SEXP, SEXP count_minSEXP, SEXP len_maxSEXP, SEXP nestedSEXP, SEXP orderedSEXP) {
@@ -170,6 +153,23 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< bool >::type nested(nestedSEXP);
     Rcpp::traits::input_parameter< bool >::type ordered(orderedSEXP);
     rcpp_result_gen = Rcpp::wrap(qatd_cpp_sequences_old(texts_, words_, types_, count_min, len_max, nested, ordered));
+    return rcpp_result_gen;
+END_RCPP
+}
+// qatd_cpp_sequences
+DataFrame qatd_cpp_sequences(const List& texts_, const CharacterVector& types_, const unsigned int count_min, unsigned int len_min, unsigned int len_max, const String& method, bool nested);
+RcppExport SEXP quanteda_qatd_cpp_sequences(SEXP texts_SEXP, SEXP types_SEXP, SEXP count_minSEXP, SEXP len_minSEXP, SEXP len_maxSEXP, SEXP methodSEXP, SEXP nestedSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const List& >::type texts_(texts_SEXP);
+    Rcpp::traits::input_parameter< const CharacterVector& >::type types_(types_SEXP);
+    Rcpp::traits::input_parameter< const unsigned int >::type count_min(count_minSEXP);
+    Rcpp::traits::input_parameter< unsigned int >::type len_min(len_minSEXP);
+    Rcpp::traits::input_parameter< unsigned int >::type len_max(len_maxSEXP);
+    Rcpp::traits::input_parameter< const String& >::type method(methodSEXP);
+    Rcpp::traits::input_parameter< bool >::type nested(nestedSEXP);
+    rcpp_result_gen = Rcpp::wrap(qatd_cpp_sequences(texts_, types_, count_min, len_min, len_max, method, nested));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -327,25 +327,6 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// wordfishcpp
-Rcpp::List wordfishcpp(arma::sp_mat& wfm, IntegerVector& dirvec, NumericVector& priorvec, NumericVector& tolvec, IntegerVector& disptype, NumericVector& dispmin, bool ABS, bool svd_on, double residual_floor);
-RcppExport SEXP quanteda_wordfishcpp(SEXP wfmSEXP, SEXP dirvecSEXP, SEXP priorvecSEXP, SEXP tolvecSEXP, SEXP disptypeSEXP, SEXP dispminSEXP, SEXP ABSSEXP, SEXP svd_onSEXP, SEXP residual_floorSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< arma::sp_mat& >::type wfm(wfmSEXP);
-    Rcpp::traits::input_parameter< IntegerVector& >::type dirvec(dirvecSEXP);
-    Rcpp::traits::input_parameter< NumericVector& >::type priorvec(priorvecSEXP);
-    Rcpp::traits::input_parameter< NumericVector& >::type tolvec(tolvecSEXP);
-    Rcpp::traits::input_parameter< IntegerVector& >::type disptype(disptypeSEXP);
-    Rcpp::traits::input_parameter< NumericVector& >::type dispmin(dispminSEXP);
-    Rcpp::traits::input_parameter< bool >::type ABS(ABSSEXP);
-    Rcpp::traits::input_parameter< bool >::type svd_on(svd_onSEXP);
-    Rcpp::traits::input_parameter< double >::type residual_floor(residual_floorSEXP);
-    rcpp_result_gen = Rcpp::wrap(wordfishcpp(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor));
-    return rcpp_result_gen;
-END_RCPP
-}
 // wordfishcpp_dense
 Rcpp::List wordfishcpp_dense(SEXP wfm, SEXP dir, SEXP priors, SEXP tol, SEXP disp, SEXP dispfloor, bool abs_err);
 RcppExport SEXP quanteda_wordfishcpp_dense(SEXP wfmSEXP, SEXP dirSEXP, SEXP priorsSEXP, SEXP tolSEXP, SEXP dispSEXP, SEXP dispfloorSEXP, SEXP abs_errSEXP) {
@@ -379,6 +360,25 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< bool >::type svd_sparse(svd_sparseSEXP);
     Rcpp::traits::input_parameter< double >::type residual_floor(residual_floorSEXP);
     rcpp_result_gen = Rcpp::wrap(wordfishcpp_mt(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_sparse, residual_floor));
+    return rcpp_result_gen;
+END_RCPP
+}
+// wordfishcpp
+Rcpp::List wordfishcpp(arma::sp_mat& wfm, IntegerVector& dirvec, NumericVector& priorvec, NumericVector& tolvec, IntegerVector& disptype, NumericVector& dispmin, bool ABS, bool svd_on, double residual_floor);
+RcppExport SEXP quanteda_wordfishcpp(SEXP wfmSEXP, SEXP dirvecSEXP, SEXP priorvecSEXP, SEXP tolvecSEXP, SEXP disptypeSEXP, SEXP dispminSEXP, SEXP ABSSEXP, SEXP svd_onSEXP, SEXP residual_floorSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< arma::sp_mat& >::type wfm(wfmSEXP);
+    Rcpp::traits::input_parameter< IntegerVector& >::type dirvec(dirvecSEXP);
+    Rcpp::traits::input_parameter< NumericVector& >::type priorvec(priorvecSEXP);
+    Rcpp::traits::input_parameter< NumericVector& >::type tolvec(tolvecSEXP);
+    Rcpp::traits::input_parameter< IntegerVector& >::type disptype(disptypeSEXP);
+    Rcpp::traits::input_parameter< NumericVector& >::type dispmin(dispminSEXP);
+    Rcpp::traits::input_parameter< bool >::type ABS(ABSSEXP);
+    Rcpp::traits::input_parameter< bool >::type svd_on(svd_onSEXP);
+    Rcpp::traits::input_parameter< double >::type residual_floor(residual_floorSEXP);
+    rcpp_result_gen = Rcpp::wrap(wordfishcpp(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -3,4 +3,6 @@ Sys.setenv("R_TESTS" = "")
 library(testthat)
 library(quanteda)
 
+quanteda_options(reset = TRUE)
 test_check("quanteda")
+

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -3,6 +3,8 @@ Sys.setenv("R_TESTS" = "")
 library(testthat)
 library(quanteda)
 
+qopts <- quanteda_options()
 quanteda_options(reset = TRUE)
 test_check("quanteda")
+quanteda_options(qopts)
 

--- a/tests/testthat/test-quanteda_options.R
+++ b/tests/testthat/test-quanteda_options.R
@@ -8,15 +8,6 @@ test_that("quanteda_options initialize works correctly", {
     expect_equal(quanteda_options("verbose"), TRUE)
 })
 
-test_that("quanteda_options reset works correctly", {
-    quanteda_options(reset = TRUE)
-    qopts <- quanteda:::QUANTEDA_OPTION_LIST
-    names(qopts) <- stringi::stri_replace_all_fixed(names(qopts), "quanteda_", "")
-    expect_equal(
-        quanteda_options(),
-        qopts        
-    )
-})
 
 test_that("quanteda_options returns an error for non-existing options", {
     expect_error(
@@ -66,4 +57,14 @@ test_that("quanteda functions work if package is not attached", {
         "Document-feature matrix of: 2 documents, 6 features"
     )
     require(quanteda)
+})
+
+test_that("quanteda_options reset works correctly", {
+    quanteda_options(reset = TRUE)
+    qopts <- quanteda:::QUANTEDA_OPTION_LIST
+    names(qopts) <- stringi::stri_replace_all_fixed(names(qopts), "quanteda_", "")
+    expect_equal(
+        quanteda_options(),
+        qopts        
+    )
 })

--- a/tests/testthat/test-quanteda_options.R
+++ b/tests/testthat/test-quanteda_options.R
@@ -48,9 +48,7 @@ test_that("quanteda_options works correctly to set options", {
 })
 
 test_that("quanteda functions work if package is not attached", {
-    skip_on_travis()
-    skip_on_appveyor()
-    skip_on_cran()
+    skip("skipping test of option setting when quanteda is not attached")
     detach("package:quanteda", unload = TRUE)
     expect_output(
         print(quanteda::dfm(c("a b c d", "a c d e f"))),


### PR DESCRIPTION
- Adds the ability to set options (through `quanteda_options()` using a list directly
- resets the options and restores them in running tests
- skips the namespace test that detaches the package, since this caused failures in the check locally (formerly it was skipped on CI and CRAN, now it's just skipped).