### PR TITLE
Issue 408

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: quanteda
-Version: 0.9.9.76
+Version: 0.9.9.77
 Title: Quantitative Analysis of Textual Data
 Description: A fast, flexible framework for for the management, processing, and
     quantitative analysis of textual data in R.

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,8 +13,9 @@
    This function is still under development and likely to change further.
 *  Added new `quanteda_options` that affect the maximum documents and features displayed by the dfm print method (#756).
 *  `ngram` formation is now significantly faster, including with skips (skipgrams).
-*  `topfeatures()` now accepts a `groups` argument that can be used to generate lists of top (or bottom) features in a group of texts, including by document (#336).
-    
+*  Improvements to `topfeatures()`:
+    - now accepts a `groups` argument that can be used to generate lists of top (or bottom) features in a group of texts, including by document (#336).
+    - new argument `scheme` that takes the default of (frequency) `"count"` but also a new `"docfreq"` value (#408).
 
 ### Behaviour changes
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -41,12 +41,12 @@ qatd_cpp_fcm <- function(texts_, n_types, count, window, weights, ordered, tri, 
     .Call(quanteda_qatd_cpp_fcm, texts_, n_types, count, window, weights, ordered, tri, nvec)
 }
 
-qatd_cpp_sequences_old <- function(texts_, words_, types_, count_min, len_max, nested, ordered = FALSE) {
-    .Call(quanteda_qatd_cpp_sequences_old, texts_, words_, types_, count_min, len_max, nested, ordered)
-}
-
 qatd_cpp_sequences <- function(texts_, types_, count_min, len_min, len_max, method, nested) {
     .Call(quanteda_qatd_cpp_sequences, texts_, types_, count_min, len_min, len_max, method, nested)
+}
+
+qatd_cpp_sequences_old <- function(texts_, words_, types_, count_min, len_max, nested, ordered = FALSE) {
+    .Call(quanteda_qatd_cpp_sequences_old, texts_, words_, types_, count_min, len_max, nested, ordered)
 }
 
 qatd_cpp_tokens_compound <- function(texts_, comps_, types_, delim_, join) {
@@ -93,15 +93,15 @@ qatd_cpp_chars_remove <- function(input_, char_remove) {
     .Call(quanteda_qatd_cpp_chars_remove, input_, char_remove)
 }
 
+wordfishcpp <- function(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor) {
+    .Call(quanteda_wordfishcpp, wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor)
+}
+
 wordfishcpp_dense <- function(wfm, dir, priors, tol, disp, dispfloor, abs_err) {
     .Call(quanteda_wordfishcpp_dense, wfm, dir, priors, tol, disp, dispfloor, abs_err)
 }
 
 wordfishcpp_mt <- function(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_sparse, residual_floor) {
     .Call(quanteda_wordfishcpp_mt, wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_sparse, residual_floor)
-}
-
-wordfishcpp <- function(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor) {
-    .Call(quanteda_wordfishcpp, wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor)
 }
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -41,12 +41,12 @@ qatd_cpp_fcm <- function(texts_, n_types, count, window, weights, ordered, tri, 
     .Call(quanteda_qatd_cpp_fcm, texts_, n_types, count, window, weights, ordered, tri, nvec)
 }
 
-qatd_cpp_sequences <- function(texts_, types_, count_min, sizes_, method, smoothing) {
-    .Call(quanteda_qatd_cpp_sequences, texts_, types_, count_min, sizes_, method, smoothing)
-}
-
 qatd_cpp_sequences_old <- function(texts_, words_, types_, count_min, len_max, nested, ordered = FALSE) {
     .Call(quanteda_qatd_cpp_sequences_old, texts_, words_, types_, count_min, len_max, nested, ordered)
+}
+
+qatd_cpp_sequences <- function(texts_, types_, count_min, sizes_, method, smoothing) {
+    .Call(quanteda_qatd_cpp_sequences, texts_, types_, count_min, sizes_, method, smoothing)
 }
 
 qatd_cpp_tokens_compound <- function(texts_, comps_, types_, delim_, join) {
@@ -93,15 +93,15 @@ qatd_cpp_chars_remove <- function(input_, char_remove) {
     .Call(quanteda_qatd_cpp_chars_remove, input_, char_remove)
 }
 
-wordfishcpp <- function(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor) {
-    .Call(quanteda_wordfishcpp, wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor)
-}
-
 wordfishcpp_dense <- function(wfm, dir, priors, tol, disp, dispfloor, abs_err) {
     .Call(quanteda_wordfishcpp_dense, wfm, dir, priors, tol, disp, dispfloor, abs_err)
 }
 
 wordfishcpp_mt <- function(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_sparse, residual_floor) {
     .Call(quanteda_wordfishcpp_mt, wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_sparse, residual_floor)
+}
+
+wordfishcpp <- function(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor) {
+    .Call(quanteda_wordfishcpp, wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor)
 }
 

--- a/R/corpus-methods-quanteda.R
+++ b/R/corpus-methods-quanteda.R
@@ -59,6 +59,10 @@ documents.tokens <- function(x) {
     docvars(x)
 }
 
+documents.dfm <- function(x) {
+    docvars(x)
+}
+
 
 # internal replacement function for documents
 # @export

--- a/R/dfm-methods.R
+++ b/R/dfm-methods.R
@@ -107,9 +107,12 @@ as.dfm <- function(x) {
 #' @param n how many top features should be returned
 #' @param decreasing If \code{TRUE}, return the \code{n} most frequent features;
 #'   otherwise return the \code{n} least frequent features
-#' @param groups either: a character vector containing the names of document
-#'   variables to be used for grouping; or a factor or object that can be
-#'   coerced into a factor equal in length or rows to the number of documents.
+#' @param scheme one of \code{count} for total feature frequency (within
+#'   \code{group} if applicable), or \code{docfreq} for the document frequencies
+#'   of features
+#' @param groups either: a character vector containing the names of document 
+#'   variables to be used for grouping; or a factor or object that can be 
+#'   coerced into a factor equal in length or rows to the number of documents. 
 #'   See \code{\link{dfm_group}} for details.
 #' @return A named numeric vector of feature counts, where the names are the 
 #'   feature labels, or a list of these if \code{groups} is given.
@@ -129,28 +132,45 @@ as.dfm <- function(x) {
 #' 
 #' # grouping by president last name
 #' topfeatures(mydfm_nostopw, n = 5, groups = "President")
+#'
+#' # features by document frequencies
+#' tail(topfeatures(mydfm, scheme = "docfreq", n = 200))
 #' @export
-topfeatures <- function(x, n = 10, decreasing = TRUE, groups = NULL) {
+topfeatures <- function(x, n = 10, decreasing = TRUE, scheme = c("count", "docfreq"), groups = NULL) {
     UseMethod("topfeatures")
 }
 
 #' @export
 #' @noRd
 #' @importFrom stats quantile
-topfeatures.dfm <- function(x, n = 10, decreasing = TRUE, groups = NULL) {
+topfeatures.dfm <- function(x, n = 10, decreasing = TRUE,  scheme = c("count", "docfreq"), groups = NULL) {
+    scheme <- match.arg(scheme)
+    
     if (!is.null(groups)) {
+        
+        if (scheme == "docfreq") {
+            stop("docfreq not yet implemented for groups")
+        }
+        
         x <- dfm_group(x, groups = groups)
         result <- list()
         for (i in seq_len(ndoc(x))) {
-            result[[i]] <- topfeatures(x[i, ], n = n, decreasing = decreasing, 
-                                       groups = NULL)
+            result[[i]] <- topfeatures(x[i, ], n = n, scheme = scheme, 
+                                       decreasing = decreasing, groups = NULL)
         }
         names(result) <- docnames(x)
         return(result)
     }
+    
     if (n > nfeature(x)) n <- nfeature(x)
     
-    result <- sort(colSums(x), decreasing)
+    if (scheme == "count") {
+        wght <- colSums(x)
+    } else if (scheme == "docfreq") {
+        wght <- docfreq(x)
+    }
+    
+    result <- sort(wght, decreasing)
     return(result[1:n])
     
     # Under development by Ken

--- a/R/dfm-methods.R
+++ b/R/dfm-methods.R
@@ -147,18 +147,13 @@ topfeatures.dfm <- function(x, n = 10, decreasing = TRUE,  scheme = c("count", "
     scheme <- match.arg(scheme)
     
     if (!is.null(groups)) {
-        
-        if (scheme == "docfreq") {
-            stop("docfreq not yet implemented for groups")
-        }
-        
-        x <- dfm_group(x, groups = groups)
+        rownames(x) <- generate_groups(x, groups)
         result <- list()
-        for (i in seq_len(ndoc(x))) {
-            result[[i]] <- topfeatures(x[i, ], n = n, scheme = scheme, 
+        for (i in unique(docnames(x))) {
+            result[[i]] <- topfeatures(x[which(rownames(x)==i), ], 
+                                       n = n, scheme = scheme, 
                                        decreasing = decreasing, groups = NULL)
         }
-        names(result) <- docnames(x)
         return(result)
     }
     

--- a/man/topfeatures.Rd
+++ b/man/topfeatures.Rd
@@ -4,7 +4,8 @@
 \alias{topfeatures}
 \title{identify the most frequent features in a dfm}
 \usage{
-topfeatures(x, n = 10, decreasing = TRUE, groups = NULL)
+topfeatures(x, n = 10, decreasing = TRUE, scheme = c("count", "docfreq"),
+  groups = NULL)
 }
 \arguments{
 \item{x}{the object whose features will be returned}
@@ -14,9 +15,13 @@ topfeatures(x, n = 10, decreasing = TRUE, groups = NULL)
 \item{decreasing}{If \code{TRUE}, return the \code{n} most frequent features;
 otherwise return the \code{n} least frequent features}
 
-\item{groups}{either: a character vector containing the names of document
-variables to be used for grouping; or a factor or object that can be
-coerced into a factor equal in length or rows to the number of documents.
+\item{scheme}{one of \code{count} for total feature frequency (within
+\code{group} if applicable), or \code{docfreq} for the document frequencies
+of features}
+
+\item{groups}{either: a character vector containing the names of document 
+variables to be used for grouping; or a factor or object that can be 
+coerced into a factor equal in length or rows to the number of documents. 
 See \code{\link{dfm_group}} for details.}
 }
 \value{
@@ -43,4 +48,7 @@ topfeatures(mydfm_nostopw, n = 5, groups = docnames(mydfm_nostopw))
 
 # grouping by president last name
 topfeatures(mydfm_nostopw, n = 5, groups = "President")
+
+# features by document frequencies
+tail(topfeatures(mydfm, scheme = "docfreq", n = 200))
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -139,23 +139,6 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// qatd_cpp_sequences_old
-DataFrame qatd_cpp_sequences_old(const List& texts_, const IntegerVector& words_, const CharacterVector& types_, const unsigned int count_min, unsigned int len_max, bool nested, bool ordered);
-RcppExport SEXP quanteda_qatd_cpp_sequences_old(SEXP texts_SEXP, SEXP words_SEXP, SEXP types_SEXP, SEXP count_minSEXP, SEXP len_maxSEXP, SEXP nestedSEXP, SEXP orderedSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const List& >::type texts_(texts_SEXP);
-    Rcpp::traits::input_parameter< const IntegerVector& >::type words_(words_SEXP);
-    Rcpp::traits::input_parameter< const CharacterVector& >::type types_(types_SEXP);
-    Rcpp::traits::input_parameter< const unsigned int >::type count_min(count_minSEXP);
-    Rcpp::traits::input_parameter< unsigned int >::type len_max(len_maxSEXP);
-    Rcpp::traits::input_parameter< bool >::type nested(nestedSEXP);
-    Rcpp::traits::input_parameter< bool >::type ordered(orderedSEXP);
-    rcpp_result_gen = Rcpp::wrap(qatd_cpp_sequences_old(texts_, words_, types_, count_min, len_max, nested, ordered));
-    return rcpp_result_gen;
-END_RCPP
-}
 // qatd_cpp_sequences
 DataFrame qatd_cpp_sequences(const List& texts_, const CharacterVector& types_, const unsigned int count_min, unsigned int len_min, unsigned int len_max, const String& method, bool nested);
 RcppExport SEXP quanteda_qatd_cpp_sequences(SEXP texts_SEXP, SEXP types_SEXP, SEXP count_minSEXP, SEXP len_minSEXP, SEXP len_maxSEXP, SEXP methodSEXP, SEXP nestedSEXP) {
@@ -170,6 +153,23 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const String& >::type method(methodSEXP);
     Rcpp::traits::input_parameter< bool >::type nested(nestedSEXP);
     rcpp_result_gen = Rcpp::wrap(qatd_cpp_sequences(texts_, types_, count_min, len_min, len_max, method, nested));
+    return rcpp_result_gen;
+END_RCPP
+}
+// qatd_cpp_sequences_old
+DataFrame qatd_cpp_sequences_old(const List& texts_, const IntegerVector& words_, const CharacterVector& types_, const unsigned int count_min, unsigned int len_max, bool nested, bool ordered);
+RcppExport SEXP quanteda_qatd_cpp_sequences_old(SEXP texts_SEXP, SEXP words_SEXP, SEXP types_SEXP, SEXP count_minSEXP, SEXP len_maxSEXP, SEXP nestedSEXP, SEXP orderedSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const List& >::type texts_(texts_SEXP);
+    Rcpp::traits::input_parameter< const IntegerVector& >::type words_(words_SEXP);
+    Rcpp::traits::input_parameter< const CharacterVector& >::type types_(types_SEXP);
+    Rcpp::traits::input_parameter< const unsigned int >::type count_min(count_minSEXP);
+    Rcpp::traits::input_parameter< unsigned int >::type len_max(len_maxSEXP);
+    Rcpp::traits::input_parameter< bool >::type nested(nestedSEXP);
+    Rcpp::traits::input_parameter< bool >::type ordered(orderedSEXP);
+    rcpp_result_gen = Rcpp::wrap(qatd_cpp_sequences_old(texts_, words_, types_, count_min, len_max, nested, ordered));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -327,6 +327,25 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// wordfishcpp
+Rcpp::List wordfishcpp(arma::sp_mat& wfm, IntegerVector& dirvec, NumericVector& priorvec, NumericVector& tolvec, IntegerVector& disptype, NumericVector& dispmin, bool ABS, bool svd_on, double residual_floor);
+RcppExport SEXP quanteda_wordfishcpp(SEXP wfmSEXP, SEXP dirvecSEXP, SEXP priorvecSEXP, SEXP tolvecSEXP, SEXP disptypeSEXP, SEXP dispminSEXP, SEXP ABSSEXP, SEXP svd_onSEXP, SEXP residual_floorSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< arma::sp_mat& >::type wfm(wfmSEXP);
+    Rcpp::traits::input_parameter< IntegerVector& >::type dirvec(dirvecSEXP);
+    Rcpp::traits::input_parameter< NumericVector& >::type priorvec(priorvecSEXP);
+    Rcpp::traits::input_parameter< NumericVector& >::type tolvec(tolvecSEXP);
+    Rcpp::traits::input_parameter< IntegerVector& >::type disptype(disptypeSEXP);
+    Rcpp::traits::input_parameter< NumericVector& >::type dispmin(dispminSEXP);
+    Rcpp::traits::input_parameter< bool >::type ABS(ABSSEXP);
+    Rcpp::traits::input_parameter< bool >::type svd_on(svd_onSEXP);
+    Rcpp::traits::input_parameter< double >::type residual_floor(residual_floorSEXP);
+    rcpp_result_gen = Rcpp::wrap(wordfishcpp(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor));
+    return rcpp_result_gen;
+END_RCPP
+}
 // wordfishcpp_dense
 Rcpp::List wordfishcpp_dense(SEXP wfm, SEXP dir, SEXP priors, SEXP tol, SEXP disp, SEXP dispfloor, bool abs_err);
 RcppExport SEXP quanteda_wordfishcpp_dense(SEXP wfmSEXP, SEXP dirSEXP, SEXP priorsSEXP, SEXP tolSEXP, SEXP dispSEXP, SEXP dispfloorSEXP, SEXP abs_errSEXP) {
@@ -360,25 +379,6 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< bool >::type svd_sparse(svd_sparseSEXP);
     Rcpp::traits::input_parameter< double >::type residual_floor(residual_floorSEXP);
     rcpp_result_gen = Rcpp::wrap(wordfishcpp_mt(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_sparse, residual_floor));
-    return rcpp_result_gen;
-END_RCPP
-}
-// wordfishcpp
-Rcpp::List wordfishcpp(arma::sp_mat& wfm, IntegerVector& dirvec, NumericVector& priorvec, NumericVector& tolvec, IntegerVector& disptype, NumericVector& dispmin, bool ABS, bool svd_on, double residual_floor);
-RcppExport SEXP quanteda_wordfishcpp(SEXP wfmSEXP, SEXP dirvecSEXP, SEXP priorvecSEXP, SEXP tolvecSEXP, SEXP disptypeSEXP, SEXP dispminSEXP, SEXP ABSSEXP, SEXP svd_onSEXP, SEXP residual_floorSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< arma::sp_mat& >::type wfm(wfmSEXP);
-    Rcpp::traits::input_parameter< IntegerVector& >::type dirvec(dirvecSEXP);
-    Rcpp::traits::input_parameter< NumericVector& >::type priorvec(priorvecSEXP);
-    Rcpp::traits::input_parameter< NumericVector& >::type tolvec(tolvecSEXP);
-    Rcpp::traits::input_parameter< IntegerVector& >::type disptype(disptypeSEXP);
-    Rcpp::traits::input_parameter< NumericVector& >::type dispmin(dispminSEXP);
-    Rcpp::traits::input_parameter< bool >::type ABS(ABSSEXP);
-    Rcpp::traits::input_parameter< bool >::type svd_on(svd_onSEXP);
-    Rcpp::traits::input_parameter< double >::type residual_floor(residual_floorSEXP);
-    rcpp_result_gen = Rcpp::wrap(wordfishcpp(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -139,22 +139,6 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// qatd_cpp_sequences
-DataFrame qatd_cpp_sequences(const List& texts_, const CharacterVector& types_, const unsigned int count_min, const IntegerVector sizes_, const String& method, const double smoothing);
-RcppExport SEXP quanteda_qatd_cpp_sequences(SEXP texts_SEXP, SEXP types_SEXP, SEXP count_minSEXP, SEXP sizes_SEXP, SEXP methodSEXP, SEXP smoothingSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const List& >::type texts_(texts_SEXP);
-    Rcpp::traits::input_parameter< const CharacterVector& >::type types_(types_SEXP);
-    Rcpp::traits::input_parameter< const unsigned int >::type count_min(count_minSEXP);
-    Rcpp::traits::input_parameter< const IntegerVector >::type sizes_(sizes_SEXP);
-    Rcpp::traits::input_parameter< const String& >::type method(methodSEXP);
-    Rcpp::traits::input_parameter< const double >::type smoothing(smoothingSEXP);
-    rcpp_result_gen = Rcpp::wrap(qatd_cpp_sequences(texts_, types_, count_min, sizes_, method, smoothing));
-    return rcpp_result_gen;
-END_RCPP
-}
 // qatd_cpp_sequences_old
 DataFrame qatd_cpp_sequences_old(const List& texts_, const IntegerVector& words_, const CharacterVector& types_, const unsigned int count_min, unsigned int len_max, bool nested, bool ordered);
 RcppExport SEXP quanteda_qatd_cpp_sequences_old(SEXP texts_SEXP, SEXP words_SEXP, SEXP types_SEXP, SEXP count_minSEXP, SEXP len_maxSEXP, SEXP nestedSEXP, SEXP orderedSEXP) {
@@ -169,6 +153,22 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< bool >::type nested(nestedSEXP);
     Rcpp::traits::input_parameter< bool >::type ordered(orderedSEXP);
     rcpp_result_gen = Rcpp::wrap(qatd_cpp_sequences_old(texts_, words_, types_, count_min, len_max, nested, ordered));
+    return rcpp_result_gen;
+END_RCPP
+}
+// qatd_cpp_sequences
+DataFrame qatd_cpp_sequences(const List& texts_, const CharacterVector& types_, const unsigned int count_min, const IntegerVector sizes_, const String& method, const double smoothing);
+RcppExport SEXP quanteda_qatd_cpp_sequences(SEXP texts_SEXP, SEXP types_SEXP, SEXP count_minSEXP, SEXP sizes_SEXP, SEXP methodSEXP, SEXP smoothingSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const List& >::type texts_(texts_SEXP);
+    Rcpp::traits::input_parameter< const CharacterVector& >::type types_(types_SEXP);
+    Rcpp::traits::input_parameter< const unsigned int >::type count_min(count_minSEXP);
+    Rcpp::traits::input_parameter< const IntegerVector >::type sizes_(sizes_SEXP);
+    Rcpp::traits::input_parameter< const String& >::type method(methodSEXP);
+    Rcpp::traits::input_parameter< const double >::type smoothing(smoothingSEXP);
+    rcpp_result_gen = Rcpp::wrap(qatd_cpp_sequences(texts_, types_, count_min, sizes_, method, smoothing));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -326,25 +326,6 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// wordfishcpp
-Rcpp::List wordfishcpp(arma::sp_mat& wfm, IntegerVector& dirvec, NumericVector& priorvec, NumericVector& tolvec, IntegerVector& disptype, NumericVector& dispmin, bool ABS, bool svd_on, double residual_floor);
-RcppExport SEXP quanteda_wordfishcpp(SEXP wfmSEXP, SEXP dirvecSEXP, SEXP priorvecSEXP, SEXP tolvecSEXP, SEXP disptypeSEXP, SEXP dispminSEXP, SEXP ABSSEXP, SEXP svd_onSEXP, SEXP residual_floorSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< arma::sp_mat& >::type wfm(wfmSEXP);
-    Rcpp::traits::input_parameter< IntegerVector& >::type dirvec(dirvecSEXP);
-    Rcpp::traits::input_parameter< NumericVector& >::type priorvec(priorvecSEXP);
-    Rcpp::traits::input_parameter< NumericVector& >::type tolvec(tolvecSEXP);
-    Rcpp::traits::input_parameter< IntegerVector& >::type disptype(disptypeSEXP);
-    Rcpp::traits::input_parameter< NumericVector& >::type dispmin(dispminSEXP);
-    Rcpp::traits::input_parameter< bool >::type ABS(ABSSEXP);
-    Rcpp::traits::input_parameter< bool >::type svd_on(svd_onSEXP);
-    Rcpp::traits::input_parameter< double >::type residual_floor(residual_floorSEXP);
-    rcpp_result_gen = Rcpp::wrap(wordfishcpp(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor));
-    return rcpp_result_gen;
-END_RCPP
-}
 // wordfishcpp_dense
 Rcpp::List wordfishcpp_dense(SEXP wfm, SEXP dir, SEXP priors, SEXP tol, SEXP disp, SEXP dispfloor, bool abs_err);
 RcppExport SEXP quanteda_wordfishcpp_dense(SEXP wfmSEXP, SEXP dirSEXP, SEXP priorsSEXP, SEXP tolSEXP, SEXP dispSEXP, SEXP dispfloorSEXP, SEXP abs_errSEXP) {
@@ -378,6 +359,25 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< bool >::type svd_sparse(svd_sparseSEXP);
     Rcpp::traits::input_parameter< double >::type residual_floor(residual_floorSEXP);
     rcpp_result_gen = Rcpp::wrap(wordfishcpp_mt(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_sparse, residual_floor));
+    return rcpp_result_gen;
+END_RCPP
+}
+// wordfishcpp
+Rcpp::List wordfishcpp(arma::sp_mat& wfm, IntegerVector& dirvec, NumericVector& priorvec, NumericVector& tolvec, IntegerVector& disptype, NumericVector& dispmin, bool ABS, bool svd_on, double residual_floor);
+RcppExport SEXP quanteda_wordfishcpp(SEXP wfmSEXP, SEXP dirvecSEXP, SEXP priorvecSEXP, SEXP tolvecSEXP, SEXP disptypeSEXP, SEXP dispminSEXP, SEXP ABSSEXP, SEXP svd_onSEXP, SEXP residual_floorSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< arma::sp_mat& >::type wfm(wfmSEXP);
+    Rcpp::traits::input_parameter< IntegerVector& >::type dirvec(dirvecSEXP);
+    Rcpp::traits::input_parameter< NumericVector& >::type priorvec(priorvecSEXP);
+    Rcpp::traits::input_parameter< NumericVector& >::type tolvec(tolvecSEXP);
+    Rcpp::traits::input_parameter< IntegerVector& >::type disptype(disptypeSEXP);
+    Rcpp::traits::input_parameter< NumericVector& >::type dispmin(dispminSEXP);
+    Rcpp::traits::input_parameter< bool >::type ABS(ABSSEXP);
+    Rcpp::traits::input_parameter< bool >::type svd_on(svd_onSEXP);
+    Rcpp::traits::input_parameter< double >::type residual_floor(residual_floorSEXP);
+    rcpp_result_gen = Rcpp::wrap(wordfishcpp(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/tests/testthat/test-dfm.R
+++ b/tests/testthat/test-dfm.R
@@ -298,13 +298,6 @@ test_that("dfm.dfm works as expected", {
     )
 })
 
-test_that("dfm-methods works as expected", {
-    mydfm <- dfm(c("This is a test", "This is also a test", "This is an odd test"))
-    expect_equivalent(as.matrix(topfeatures(mydfm)),
-                      matrix(c(3,3,3,2,1,1,1)))
-    
-})
-
 test_that("dfm_sample works as expected",{
     myDfm <- dfm(data_corpus_inaugural[1:10], verbose = FALSE)
     expect_error(dfm_sample(myDfm, what="documents", size = 20),
@@ -453,16 +446,6 @@ test_that("cannot supply remove and select in one call (#793)", {
         dfm(toks, select = "one", remove = "two"),
         "only one of select and remove may be supplied at once"
     )
-})
-
-test_that("grouping is working as expected", {
-    mydfm <- dfm(data_corpus_inaugural[1:10])
-    expect_equal(names(topfeatures(mydfm, groups = docnames(mydfm))),
-                 docnames(mydfm))
-    expect_equal(topfeatures(mydfm, groups = docnames(mydfm))[[5]],
-                 topfeatures(mydfm[5,]))
-    expect_equal(topfeatures(mydfm, decreasing = TRUE, groups = docnames(mydfm))[[10]],
-                 topfeatures(mydfm[10,], decreasing = TRUE))
 })
 
 test_that("printing an empty dfm produces informative result (#811)", {

--- a/tests/testthat/test-sequences.R
+++ b/tests/testthat/test-sequences.R
@@ -180,8 +180,8 @@ test_that("test the correctness of significant: against stats package", {
     toks_df_2x2 <- table(tt[,c(3,5)])
     statss <- stats::loglin(toks_df_2x2, margin=1:2)
     
-    seqs <- sequences(tokens(txt), size = 3, smoothing =0)
-    expect_equal(seqs$collocation[3], 'capital gains tax')
-    expect_equal(seqs$G2[3], statss$lrt, tolerance = 1e-3)
-    expect_equal(seqs$chi2[3], statss$pearson, tolerance = 1e-3)
+    # seqs <- sequences(tokens(txt), size = 3, smoothing =0)
+    # expect_equal(seqs$collocation[3], 'capital gains tax')
+    # expect_equal(seqs$G2[3], statss$lrt, tolerance = 1e-3)
+    # expect_equal(seqs$chi2[3], statss$pearson, tolerance = 1e-3)
 })

--- a/tests/testthat/test-sequences.R
+++ b/tests/testthat/test-sequences.R
@@ -180,8 +180,9 @@ test_that("test the correctness of significant: against stats package", {
     toks_df_2x2 <- table(tt[,c(3,5)])
     statss <- stats::loglin(toks_df_2x2, margin=1:2)
     
-    # seqs <- sequences(tokens(txt), size = 3, smoothing =0)
-    # expect_equal(seqs$collocation[3], 'capital gains tax')
-    # expect_equal(seqs$G2[3], statss$lrt, tolerance = 1e-3)
-    # expect_equal(seqs$chi2[3], statss$pearson, tolerance = 1e-3)
+    seqs <- sequences(tokens(txt), size = 3, smoothing = 0)
+    cgt_index <- which(seqs$collocation == "capital gains tax")
+    expect_equal(seqs$collocation[cgt_index], 'capital gains tax')
+    expect_equal(seqs$G2[cgt_index], statss$lrt, tolerance = 1e-3)
+    expect_equal(seqs$chi2[cgt_index], statss$pearson, tolerance = 1e-3)
 })

--- a/tests/testthat/test-topfeatures.R
+++ b/tests/testthat/test-topfeatures.R
@@ -1,0 +1,60 @@
+context("tests of teopfeatures")
+
+test_that("topfeatures works with both scheme types", {
+    mydfm <- dfm(c("This is a test", "Also also also a test", "This is also an odd test"))
+    expect_equal(
+        topfeatures(mydfm),
+        c(also = 4, test = 3, this = 2, is = 2, a = 2, an = 1, odd = 1) 
+    )
+    expect_equal(
+        topfeatures(mydfm, scheme = "docfreq"),
+        c(test = 3, this = 2, is = 2, a = 2, also = 2, an = 1, odd = 1) 
+    )
+})
+
+test_that("topfeatures works with decreasing = FALSE", {
+    mydfm <- dfm(c("This is a test", "Also also also a test", "This is also an odd test"))
+    expect_equal(
+        topfeatures(mydfm, decreasing = FALSE),
+        sort(c(also = 4, test = 3, this = 2, is = 2, a = 2, an = 1, odd = 1)) 
+    )
+    expect_equal(
+        topfeatures(mydfm, scheme = "docfreq", decreasing = FALSE),
+        sort(c(test = 3, this = 2, is = 2, a = 2, also = 2, an = 1, odd = 1))
+    )
+})
+
+test_that("topfeatures works with n greater than length of features", {
+    mydfm <- dfm(c("This is a test", "Also also also a test", "This is also an odd test"))
+    expect_equal(
+        topfeatures(mydfm, n = 20),
+        c(also = 4, test = 3, this = 2, is = 2, a = 2, an = 1, odd = 1)  
+    )
+})
+
+test_that("topfeatures grouping is working", {
+    mydfm <- dfm(data_corpus_inaugural[1:10])
+    expect_equal(names(topfeatures(mydfm, groups = docnames(mydfm))),
+                 docnames(mydfm))
+    expect_equal(topfeatures(mydfm, groups = docnames(mydfm))[[5]],
+                 topfeatures(mydfm[5,]))
+    expect_equal(topfeatures(mydfm, decreasing = TRUE, groups = docnames(mydfm))[[10]],
+                 topfeatures(mydfm[10,], decreasing = TRUE))
+
+    mydfm <- dfm(c("This is a test", "Also also also a test", "This is also an odd test"))
+    grps <- c("a", "a", "b")
+    expect_equal(topfeatures(mydfm, scheme = "count", groups = grps)[["a"]],
+                 sort(colSums(mydfm[1:2, ]), decreasing = TRUE))
+    expect_equal(topfeatures(mydfm, scheme = "count", groups = grps)[["b"]],
+                 sort(colSums(mydfm[3, ]), decreasing = TRUE))
+    
+    ## not implemented yet
+    # expect_equal(topfeatures(mydfm, scheme = "docfreq", groups = grps)[["a"]],
+    #              sort(docfreq(mydfm[1:2, ]), decreasing = TRUE))
+    # expect_equal(topfeatures(mydfm, scheme = "docfreq", groups = grps)[["b"]],
+    #              sort(docfreq(mydfm[3, ]), decreasing = TRUE))
+    expect_error(
+        topfeatures(mydfm, scheme = "docfreq", groups = grps),
+        "docfreq not yet implemented for groups"
+    )
+})

--- a/tests/testthat/test-topfeatures.R
+++ b/tests/testthat/test-topfeatures.R
@@ -48,13 +48,8 @@ test_that("topfeatures grouping is working", {
     expect_equal(topfeatures(mydfm, scheme = "count", groups = grps)[["b"]],
                  sort(colSums(mydfm[3, ]), decreasing = TRUE))
     
-    ## not implemented yet
-    # expect_equal(topfeatures(mydfm, scheme = "docfreq", groups = grps)[["a"]],
-    #              sort(docfreq(mydfm[1:2, ]), decreasing = TRUE))
-    # expect_equal(topfeatures(mydfm, scheme = "docfreq", groups = grps)[["b"]],
-    #              sort(docfreq(mydfm[3, ]), decreasing = TRUE))
-    expect_error(
-        topfeatures(mydfm, scheme = "docfreq", groups = grps),
-        "docfreq not yet implemented for groups"
-    )
+    expect_equal(topfeatures(mydfm, scheme = "docfreq", groups = grps)[["a"]],
+                 sort(docfreq(mydfm[1:2, ]), decreasing = TRUE))
+    expect_equal(topfeatures(mydfm, scheme = "docfreq", groups = grps)[["b"]],
+                 sort(docfreq(mydfm[3, ]), decreasing = TRUE))
 })


### PR DESCRIPTION
Adds docfreq as a way to rank features using `topfeatures()`.

- Solves #408.
- Not yet possible to use `groups` as well as `scheme = "docfreq"`, but this is easily solved.
