### PR TITLE
Fix bug that allocate huge amount of memory when there is no match

### DIFF
--- a/src/recompile.h
+++ b/src/recompile.h
@@ -77,7 +77,7 @@ inline Tokens recompile(Texts texts,
     std::vector<bool> flags_unique(ids_new.size(), false);
     //Rcout << setw(10) << "" << ": " << 0 << " -> " << ids_new[0] << "\n";
     
-    dev::Timer timer;
+    /// dev::Timer timer;
     
     // Check if IDs are all used
     bool all_used;

--- a/src/tokens_lookup_mt.cpp
+++ b/src/tokens_lookup_mt.cpp
@@ -105,8 +105,13 @@ List qatd_cpp_tokens_lookup(const List &texts_,
     
     Texts texts = Rcpp::as<Texts>(texts_);
     Types types = Rcpp::as<Types>(types_);
-    const unsigned int id_max = Rcpp::max(ids_);
+    unsigned int id_max(0);
+    if (ids_.size() > 0) id_max = Rcpp::max(ids_);
+    // Rcout << id_max << "\n";
     
+    //dev::Timer timer;
+    
+    //dev::start_timer("Map construction", timer);
     MultiMapNgrams map_keys;
     std::vector<std::size_t> spans(keys_.size());
     for (unsigned int g = 0; g < (unsigned int)keys_.size(); g++) {
@@ -119,8 +124,9 @@ List qatd_cpp_tokens_lookup(const List &texts_,
     spans.erase(unique(spans.begin(), spans.end()), spans.end());
     std::reverse(std::begin(spans), std::end(spans));
     
-    // dev::Timer timer;
-    // dev::start_timer("Dictionary lookup", timer);
+    //dev::stop_timer("Map construction", timer);
+    
+    //dev::start_timer("Dictionary lookup", timer);
 #if QUANTEDA_USE_TBB
     lookup_mt lookup_mt(texts, spans, id_max, overlap, map_keys);
     parallelFor(0, texts.size(), lookup_mt);
@@ -129,7 +135,7 @@ List qatd_cpp_tokens_lookup(const List &texts_,
         texts[h] = lookup(texts[h], spans, id_max, overlap, map_keys);
     }
 #endif
-    // dev::stop_timer("Dictionary lookup", timer);
+    //dev::stop_timer("Dictionary lookup", timer);
     return recompile(texts, types, true, true, is_encoded(types_));
 }
 
@@ -137,11 +143,12 @@ List qatd_cpp_tokens_lookup(const List &texts_,
 
 toks <- list(rep(1:10, 1), rep(5:15, 1))
 #dict <- list(c(1, 2), c(5, 6), 10, 15, 20)
-dict <- list(5, c(5, 6) , 4)
+#dict <- list(5, c(5, 6) , 4)
+dict <- list(100, c(200, 201))
 #dict <- list(1, 10, 20)
 #keys <- seq_along(dict)
 keys <- rep(1, length(dict))
-qatd_cpp_tokens_lookup(toks, letters, dict, keys, FALSE)
+qatd_cpp_tokens_lookup(toks, letters, dict, integer(0), TRUE)
 qatd_cpp_tokens_lookup(toks, letters, dict, keys, TRUE)
 
 


### PR DESCRIPTION
This fixes a bug that `tokens_lookup()` allocates a huge amount of memory when there is no match.