### PR TITLE
Fix reordering of features in dfm_trim

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -41,12 +41,12 @@ qatd_cpp_fcm <- function(texts_, n_types, count, window, weights, ordered, tri, 
     .Call(quanteda_qatd_cpp_fcm, texts_, n_types, count, window, weights, ordered, tri, nvec)
 }
 
-qatd_cpp_sequences <- function(texts_, types_, count_min, sizes_, method, smoothing) {
-    .Call(quanteda_qatd_cpp_sequences, texts_, types_, count_min, sizes_, method, smoothing)
-}
-
 qatd_cpp_sequences_old <- function(texts_, words_, types_, count_min, len_max, nested, ordered = FALSE) {
     .Call(quanteda_qatd_cpp_sequences_old, texts_, words_, types_, count_min, len_max, nested, ordered)
+}
+
+qatd_cpp_sequences <- function(texts_, types_, count_min, sizes_, method, smoothing) {
+    .Call(quanteda_qatd_cpp_sequences, texts_, types_, count_min, sizes_, method, smoothing)
 }
 
 qatd_cpp_tokens_compound <- function(texts_, comps_, types_, delim_, join) {
@@ -93,15 +93,15 @@ qatd_cpp_tbb_enabled <- function() {
     .Call(quanteda_qatd_cpp_tbb_enabled)
 }
 
-wordfishcpp <- function(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor) {
-    .Call(quanteda_wordfishcpp, wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor)
-}
-
 wordfishcpp_dense <- function(wfm, dir, priors, tol, disp, dispfloor, abs_err) {
     .Call(quanteda_wordfishcpp_dense, wfm, dir, priors, tol, disp, dispfloor, abs_err)
 }
 
 wordfishcpp_mt <- function(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_sparse, residual_floor) {
     .Call(quanteda_wordfishcpp_mt, wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_sparse, residual_floor)
+}
+
+wordfishcpp <- function(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor) {
+    .Call(quanteda_wordfishcpp, wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor)
 }
 

--- a/R/dfm_subset.R
+++ b/R/dfm_subset.R
@@ -1,17 +1,26 @@
 #' extract a subset of a dfm
 #' 
-#' Returns \emph{document} subsets of a dfm that meet certain conditions, including direct 
-#' logical operations on docvars (document-level variables).  \code{dfm_subset}
-#' functions identically to \code{\link{subset.data.frame}}, using non-standard
-#' evaluation to evaluate conditions based on the \link{docvars} in the dfm.
+#' Returns \emph{document} subsets of a dfm that meet certain conditions,
+#' including direct logical operations on docvars (document-level variables). 
+#' \code{dfm_subset} functions identically to \code{\link{subset.data.frame}},
+#' using non-standard evaluation to evaluate conditions based on the
+#' \link{docvars} in the dfm.
 #' 
 #' To select or subset \emph{features}, see \code{\link{dfm_select}} instead.
 #' @param x \link{dfm} object to be subsetted
-#' @param subset logical expression indicating the documents to keep: missing
+#' @param subset logical expression indicating the documents to keep: missing 
 #'   values are taken as false
-#' @param select expression, indicating the docvars to select from the dfm
+#' @param select expression, indicating the docvars to select from the dfm; or a
+#'   dfm, in which case the returned dfm will contain the same documents as the
+#'   original dfm, even if these are empty.  See Details.
 #' @param ... not used
-#' @return \link{dfm} object, with a subset of documents (and docvars) selected according to arguments
+#' @return \link{dfm} object, with a subset of documents (and docvars) selected
+#'   according to arguments
+#' @details When \code{select} is a dfm, then the returned dfm will be equal in
+#'   row dimensions and order to the dfm used for selection.  This is the
+#'   document-level version of using \code{\link{dfm_select}} where
+#'   \code{pattern} is a dfm: that function matches features, while
+#'   \code{dfm_subset} will match documents.
 #' @export
 #' @seealso \code{\link{subset.data.frame}}
 #' @keywords corpus
@@ -20,8 +29,16 @@
 #'                      d3 = "b b c e", d4 = "e e f a b"),
 #'                    docvars = data.frame(grp = c(1, 1, 2, 3)))
 #' testdfm <- dfm(testcorp)
+#' # selecting on a docvars condition
 #' dfm_subset(testdfm, grp > 1)
+#' # selecting on a supplied vector
 #' dfm_subset(testdfm, c(TRUE, FALSE, TRUE, FALSE))
+#' 
+#' # selecting on a dfm
+#' dfm1 <- dfm(c(d1 = "a b b c", d2 = "b b c d"))
+#' dfm2 <- dfm(c(d1 = "x y z", d2 = "a b c c d", d3 = "x x x"))
+#' dfm_subset(dfm1, subset = dfm2)
+#' dfm_subset(dfm1, subset = dfm2[c(3,1,2), ])
 dfm_subset <- function(x, subset, select, ...) {
     UseMethod("dfm_subset")
 }
@@ -33,13 +50,23 @@ dfm_subset.dfm <- function(x, subset, select, ...) {
 
     if (length(addedArgs <- list(...)))
         warning("Argument", if (length(addedArgs) > 1L) "s " else " ", names(addedArgs), " not used.", sep = "")
+    
     r <- if (missing(subset)) {
         rep_len(TRUE, nrow(docvars(x)))
     } else {
         e <- substitute(subset)
         r <- eval(e, docvars(x), parent.frame())
-        r & !is.na(r)
+        if (is.dfm(r)) {
+            if (!missing(select)) stop("cannot select docvars if subset is a dfm")
+            x <- x[which(docnames(x) %in% docnames(r)), ]
+            return(dfm_group(dfm_trim(x, min_count = 1, min_docfreq = 1, verbose = FALSE), 
+                             groups = factor(docnames(x), levels = docnames(r)),
+                             fill = TRUE))
+        } else {
+            r & !is.na(r)
+        }
     }
+
     vars <- if (missing(select)) {
         TRUE
     } else {
@@ -47,8 +74,8 @@ dfm_subset.dfm <- function(x, subset, select, ...) {
         names(nl) <- names(docvars(x))
         eval(substitute(select), nl, parent.frame())
     }
-    
     docvars(x) <- docvars(x)[, vars, drop = FALSE]
+    
     x[which(r), ]
 }
 

--- a/R/dfm_trim.R
+++ b/R/dfm_trim.R
@@ -121,12 +121,11 @@ dfm_trim.dfm <- function(x, min_count = 1, min_docfreq = 1, max_count = NULL, ma
     
     # in case no features were removed as a result of filtering conditions
     if (!length(c(featIndexMinCount, featIndexMaxCount, featIndexMinDoc, featIndexMaxDoc))) {
-        catm("No features removed.", appendLF = TRUE)
+        if (verbose) catm("No features removed.", appendLF = TRUE)
         return(x)
     }
     
-    if (verbose)
-        catm("Removing features occurring: ", appendLF = TRUE)
+    if (verbose) catm("Removing features occurring: ", appendLF = TRUE)
     
     # print messages about frequency count removal
     if (verbose & length(c(featIndexMinCount, featIndexMaxCount))) {
@@ -167,9 +166,10 @@ dfm_trim.dfm <- function(x, min_count = 1, min_docfreq = 1, max_count = NULL, ma
              " (", format(length(featureRemoveIndex) / nfeature(x) * 100, digits = 3, nsmall = 1), "%).", 
              sep = "", appendLF = TRUE)
     }
-    if ((nfeature(x) - length(featureRemoveIndex)) == 0)  
+    if (verbose && (nfeature(x) - length(featureRemoveIndex)) == 0)
         stop("No features left after trimming.")
     
-    dfm_sort(x[, -featureRemoveIndex])
+    # dfm_sort(x[, -featureRemoveIndex])
+    x[, -featureRemoveIndex]
 }
 

--- a/man/dfm_subset.Rd
+++ b/man/dfm_subset.Rd
@@ -9,32 +9,50 @@ dfm_subset(x, subset, select, ...)
 \arguments{
 \item{x}{\link{dfm} object to be subsetted}
 
-\item{subset}{logical expression indicating the documents to keep: missing
+\item{subset}{logical expression indicating the documents to keep: missing 
 values are taken as false}
 
-\item{select}{expression, indicating the docvars to select from the dfm}
+\item{select}{expression, indicating the docvars to select from the dfm; or a
+dfm, in which case the returned dfm will contain the same documents as the
+original dfm, even if these are empty.  See Details.}
 
 \item{...}{not used}
 }
 \value{
-\link{dfm} object, with a subset of documents (and docvars) selected according to arguments
+\link{dfm} object, with a subset of documents (and docvars) selected
+  according to arguments
 }
 \description{
-Returns \emph{document} subsets of a dfm that meet certain conditions, including direct 
-logical operations on docvars (document-level variables).  \code{dfm_subset}
-functions identically to \code{\link{subset.data.frame}}, using non-standard
-evaluation to evaluate conditions based on the \link{docvars} in the dfm.
+Returns \emph{document} subsets of a dfm that meet certain conditions,
+including direct logical operations on docvars (document-level variables). 
+\code{dfm_subset} functions identically to \code{\link{subset.data.frame}},
+using non-standard evaluation to evaluate conditions based on the
+\link{docvars} in the dfm.
 }
 \details{
 To select or subset \emph{features}, see \code{\link{dfm_select}} instead.
+
+When \code{select} is a dfm, then the returned dfm will be equal in
+  row dimensions and order to the dfm used for selection.  This is the
+  document-level version of using \code{\link{dfm_select}} where
+  \code{pattern} is a dfm: that function matches features, while
+  \code{dfm_subset} will match documents.
 }
 \examples{
 testcorp <- corpus(c(d1 = "a b c d", d2 = "a a b e",
                      d3 = "b b c e", d4 = "e e f a b"),
                    docvars = data.frame(grp = c(1, 1, 2, 3)))
 testdfm <- dfm(testcorp)
+# selecting on a docvars condition
 dfm_subset(testdfm, grp > 1)
+# selecting on a supplied vector
 dfm_subset(testdfm, c(TRUE, FALSE, TRUE, FALSE))
+
+# selecting on a dfm
+dfm1 <- dfm(c(d1 = "a b b c", d2 = "b b c d"))
+dfm2 <- dfm(c(d1 = "x y z", d2 = "a b c c d", d3 = "x x x"))
+dfm_subset(dfm1, subset = dfm2)
+dfm_subset(dfm1, subset = dfm2[c(3,1,2), ])
 }
 \seealso{
 \code{\link{subset.data.frame}}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -139,22 +139,6 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// qatd_cpp_sequences
-DataFrame qatd_cpp_sequences(const List& texts_, const CharacterVector& types_, const unsigned int count_min, const IntegerVector sizes_, const String& method, const double smoothing);
-RcppExport SEXP quanteda_qatd_cpp_sequences(SEXP texts_SEXP, SEXP types_SEXP, SEXP count_minSEXP, SEXP sizes_SEXP, SEXP methodSEXP, SEXP smoothingSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const List& >::type texts_(texts_SEXP);
-    Rcpp::traits::input_parameter< const CharacterVector& >::type types_(types_SEXP);
-    Rcpp::traits::input_parameter< const unsigned int >::type count_min(count_minSEXP);
-    Rcpp::traits::input_parameter< const IntegerVector >::type sizes_(sizes_SEXP);
-    Rcpp::traits::input_parameter< const String& >::type method(methodSEXP);
-    Rcpp::traits::input_parameter< const double >::type smoothing(smoothingSEXP);
-    rcpp_result_gen = Rcpp::wrap(qatd_cpp_sequences(texts_, types_, count_min, sizes_, method, smoothing));
-    return rcpp_result_gen;
-END_RCPP
-}
 // qatd_cpp_sequences_old
 DataFrame qatd_cpp_sequences_old(const List& texts_, const IntegerVector& words_, const CharacterVector& types_, const unsigned int count_min, unsigned int len_max, bool nested, bool ordered);
 RcppExport SEXP quanteda_qatd_cpp_sequences_old(SEXP texts_SEXP, SEXP words_SEXP, SEXP types_SEXP, SEXP count_minSEXP, SEXP len_maxSEXP, SEXP nestedSEXP, SEXP orderedSEXP) {
@@ -169,6 +153,22 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< bool >::type nested(nestedSEXP);
     Rcpp::traits::input_parameter< bool >::type ordered(orderedSEXP);
     rcpp_result_gen = Rcpp::wrap(qatd_cpp_sequences_old(texts_, words_, types_, count_min, len_max, nested, ordered));
+    return rcpp_result_gen;
+END_RCPP
+}
+// qatd_cpp_sequences
+DataFrame qatd_cpp_sequences(const List& texts_, const CharacterVector& types_, const unsigned int count_min, const IntegerVector sizes_, const String& method, const double smoothing);
+RcppExport SEXP quanteda_qatd_cpp_sequences(SEXP texts_SEXP, SEXP types_SEXP, SEXP count_minSEXP, SEXP sizes_SEXP, SEXP methodSEXP, SEXP smoothingSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const List& >::type texts_(texts_SEXP);
+    Rcpp::traits::input_parameter< const CharacterVector& >::type types_(types_SEXP);
+    Rcpp::traits::input_parameter< const unsigned int >::type count_min(count_minSEXP);
+    Rcpp::traits::input_parameter< const IntegerVector >::type sizes_(sizes_SEXP);
+    Rcpp::traits::input_parameter< const String& >::type method(methodSEXP);
+    Rcpp::traits::input_parameter< const double >::type smoothing(smoothingSEXP);
+    rcpp_result_gen = Rcpp::wrap(qatd_cpp_sequences(texts_, types_, count_min, sizes_, method, smoothing));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -322,25 +322,6 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// wordfishcpp
-Rcpp::List wordfishcpp(arma::sp_mat& wfm, IntegerVector& dirvec, NumericVector& priorvec, NumericVector& tolvec, IntegerVector& disptype, NumericVector& dispmin, bool ABS, bool svd_on, double residual_floor);
-RcppExport SEXP quanteda_wordfishcpp(SEXP wfmSEXP, SEXP dirvecSEXP, SEXP priorvecSEXP, SEXP tolvecSEXP, SEXP disptypeSEXP, SEXP dispminSEXP, SEXP ABSSEXP, SEXP svd_onSEXP, SEXP residual_floorSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< arma::sp_mat& >::type wfm(wfmSEXP);
-    Rcpp::traits::input_parameter< IntegerVector& >::type dirvec(dirvecSEXP);
-    Rcpp::traits::input_parameter< NumericVector& >::type priorvec(priorvecSEXP);
-    Rcpp::traits::input_parameter< NumericVector& >::type tolvec(tolvecSEXP);
-    Rcpp::traits::input_parameter< IntegerVector& >::type disptype(disptypeSEXP);
-    Rcpp::traits::input_parameter< NumericVector& >::type dispmin(dispminSEXP);
-    Rcpp::traits::input_parameter< bool >::type ABS(ABSSEXP);
-    Rcpp::traits::input_parameter< bool >::type svd_on(svd_onSEXP);
-    Rcpp::traits::input_parameter< double >::type residual_floor(residual_floorSEXP);
-    rcpp_result_gen = Rcpp::wrap(wordfishcpp(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor));
-    return rcpp_result_gen;
-END_RCPP
-}
 // wordfishcpp_dense
 Rcpp::List wordfishcpp_dense(SEXP wfm, SEXP dir, SEXP priors, SEXP tol, SEXP disp, SEXP dispfloor, bool abs_err);
 RcppExport SEXP quanteda_wordfishcpp_dense(SEXP wfmSEXP, SEXP dirSEXP, SEXP priorsSEXP, SEXP tolSEXP, SEXP dispSEXP, SEXP dispfloorSEXP, SEXP abs_errSEXP) {
@@ -374,6 +355,25 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< bool >::type svd_sparse(svd_sparseSEXP);
     Rcpp::traits::input_parameter< double >::type residual_floor(residual_floorSEXP);
     rcpp_result_gen = Rcpp::wrap(wordfishcpp_mt(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_sparse, residual_floor));
+    return rcpp_result_gen;
+END_RCPP
+}
+// wordfishcpp
+Rcpp::List wordfishcpp(arma::sp_mat& wfm, IntegerVector& dirvec, NumericVector& priorvec, NumericVector& tolvec, IntegerVector& disptype, NumericVector& dispmin, bool ABS, bool svd_on, double residual_floor);
+RcppExport SEXP quanteda_wordfishcpp(SEXP wfmSEXP, SEXP dirvecSEXP, SEXP priorvecSEXP, SEXP tolvecSEXP, SEXP disptypeSEXP, SEXP dispminSEXP, SEXP ABSSEXP, SEXP svd_onSEXP, SEXP residual_floorSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< arma::sp_mat& >::type wfm(wfmSEXP);
+    Rcpp::traits::input_parameter< IntegerVector& >::type dirvec(dirvecSEXP);
+    Rcpp::traits::input_parameter< NumericVector& >::type priorvec(priorvecSEXP);
+    Rcpp::traits::input_parameter< NumericVector& >::type tolvec(tolvecSEXP);
+    Rcpp::traits::input_parameter< IntegerVector& >::type disptype(disptypeSEXP);
+    Rcpp::traits::input_parameter< NumericVector& >::type dispmin(dispminSEXP);
+    Rcpp::traits::input_parameter< bool >::type ABS(ABSSEXP);
+    Rcpp::traits::input_parameter< bool >::type svd_on(svd_onSEXP);
+    Rcpp::traits::input_parameter< double >::type residual_floor(residual_floorSEXP);
+    rcpp_result_gen = Rcpp::wrap(wordfishcpp(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/tests/testthat/test-dfm_subset.R
+++ b/tests/testthat/test-dfm_subset.R
@@ -55,3 +55,18 @@ test_that("dfm_subset NSE works", {
     )
 })
 
+test_that("dfm_subset works with subset as a dfm", {
+    dfm1 <- dfm(c(d1 = "a b b c", d2 = "b b c d"))
+    dfm2 <- dfm(c(d1 = "x y z", d2 = "a b c c d", d3 = "a b c", d4 = "x x x"))
+    expect_equal(
+        as.matrix(dfm_subset(dfm1, subset = dfm2)),
+        matrix(c(1,2,1,0, 0,2,1,1, rep(0,8)), byrow = TRUE, nrow = 4, 
+               dimnames = list(docs = paste0("d", 1:4), features = letters[1:4]))
+    )
+    
+    expect_equal(
+        as.matrix(dfm_subset(dfm1, subset = dfm2[c(3,4,1,2), ])),
+        matrix(c(rep(0,8), 1,2,1,0, 0,2,1,1), byrow = TRUE, nrow = 4, 
+               dimnames = list(docs = paste0("d", c(3,4,1,2)), features = letters[1:4]))
+    )
+})


### PR DESCRIPTION
Fixes the reordering of features in `dfm_trim()` - solves #858.

Also implements selection on a dfm for `dfm_subset()`, per discussion here: https://github.com/kbenoit/quanteda/issues/859.