### PR TITLE
Fix issue 829, dfm_trim breaking when dfm contains duplicated featnames

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -41,12 +41,12 @@ qatd_cpp_fcm <- function(texts_, n_types, count, window, weights, ordered, tri, 
     .Call(quanteda_qatd_cpp_fcm, texts_, n_types, count, window, weights, ordered, tri, nvec)
 }
 
-qatd_cpp_sequences_old <- function(texts_, words_, types_, count_min, len_max, nested, ordered = FALSE) {
-    .Call(quanteda_qatd_cpp_sequences_old, texts_, words_, types_, count_min, len_max, nested, ordered)
-}
-
 qatd_cpp_sequences <- function(texts_, types_, count_min, sizes_, method, smoothing) {
     .Call(quanteda_qatd_cpp_sequences, texts_, types_, count_min, sizes_, method, smoothing)
+}
+
+qatd_cpp_sequences_old <- function(texts_, words_, types_, count_min, len_max, nested, ordered = FALSE) {
+    .Call(quanteda_qatd_cpp_sequences_old, texts_, words_, types_, count_min, len_max, nested, ordered)
 }
 
 qatd_cpp_tokens_compound <- function(texts_, comps_, types_, delim_, join) {
@@ -93,15 +93,15 @@ qatd_cpp_tbb_enabled <- function() {
     .Call(quanteda_qatd_cpp_tbb_enabled)
 }
 
+wordfishcpp <- function(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor) {
+    .Call(quanteda_wordfishcpp, wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor)
+}
+
 wordfishcpp_dense <- function(wfm, dir, priors, tol, disp, dispfloor, abs_err) {
     .Call(quanteda_wordfishcpp_dense, wfm, dir, priors, tol, disp, dispfloor, abs_err)
 }
 
 wordfishcpp_mt <- function(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_sparse, residual_floor) {
     .Call(quanteda_wordfishcpp_mt, wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_sparse, residual_floor)
-}
-
-wordfishcpp <- function(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor) {
-    .Call(quanteda_wordfishcpp, wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor)
 }
 

--- a/R/dfm_weight.R
+++ b/R/dfm_weight.R
@@ -212,9 +212,10 @@ docfreq.dfm <- function(x, scheme = c("count", "inverse", "inversemax", "inverse
         
     } else if (scheme == "count") {
         if (is(x, "dfmSparse")) {
-            tx <- t(x)
-            featfactor <- factor(tx@i, 0:(nfeature(x)-1), labels = featnames(x))
-            result <- as.integer(table(featfactor[tx@x > threshold]))
+            result <- colSums(x > threshold)
+            # tx <- t(x)
+            # featfactor <- factor(tx@i, 0:(nfeature(x)-1), labels = featnames(x))
+            # result <- as.integer(table(featfactor[tx@x > threshold]))
         } else {
             if (!any(x@x <= threshold)) 
                 result <- rep(ndoc(x), nfeature(x))
@@ -235,7 +236,7 @@ docfreq.dfm <- function(x, scheme = c("count", "inverse", "inversemax", "inverse
         result <- pmax(0, result)
     }
     
-    if (USE.NAMES) names(result) <- featnames(x)
+    if (USE.NAMES) names(result) <- featnames(x) else names(result) <- NULL
     result
 }
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -139,6 +139,22 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// qatd_cpp_sequences
+DataFrame qatd_cpp_sequences(const List& texts_, const CharacterVector& types_, const unsigned int count_min, const IntegerVector sizes_, const String& method, const double smoothing);
+RcppExport SEXP quanteda_qatd_cpp_sequences(SEXP texts_SEXP, SEXP types_SEXP, SEXP count_minSEXP, SEXP sizes_SEXP, SEXP methodSEXP, SEXP smoothingSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const List& >::type texts_(texts_SEXP);
+    Rcpp::traits::input_parameter< const CharacterVector& >::type types_(types_SEXP);
+    Rcpp::traits::input_parameter< const unsigned int >::type count_min(count_minSEXP);
+    Rcpp::traits::input_parameter< const IntegerVector >::type sizes_(sizes_SEXP);
+    Rcpp::traits::input_parameter< const String& >::type method(methodSEXP);
+    Rcpp::traits::input_parameter< const double >::type smoothing(smoothingSEXP);
+    rcpp_result_gen = Rcpp::wrap(qatd_cpp_sequences(texts_, types_, count_min, sizes_, method, smoothing));
+    return rcpp_result_gen;
+END_RCPP
+}
 // qatd_cpp_sequences_old
 DataFrame qatd_cpp_sequences_old(const List& texts_, const IntegerVector& words_, const CharacterVector& types_, const unsigned int count_min, unsigned int len_max, bool nested, bool ordered);
 RcppExport SEXP quanteda_qatd_cpp_sequences_old(SEXP texts_SEXP, SEXP words_SEXP, SEXP types_SEXP, SEXP count_minSEXP, SEXP len_maxSEXP, SEXP nestedSEXP, SEXP orderedSEXP) {
@@ -153,22 +169,6 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< bool >::type nested(nestedSEXP);
     Rcpp::traits::input_parameter< bool >::type ordered(orderedSEXP);
     rcpp_result_gen = Rcpp::wrap(qatd_cpp_sequences_old(texts_, words_, types_, count_min, len_max, nested, ordered));
-    return rcpp_result_gen;
-END_RCPP
-}
-// qatd_cpp_sequences
-DataFrame qatd_cpp_sequences(const List& texts_, const CharacterVector& types_, const unsigned int count_min, const IntegerVector sizes_, const String& method, const double smoothing);
-RcppExport SEXP quanteda_qatd_cpp_sequences(SEXP texts_SEXP, SEXP types_SEXP, SEXP count_minSEXP, SEXP sizes_SEXP, SEXP methodSEXP, SEXP smoothingSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const List& >::type texts_(texts_SEXP);
-    Rcpp::traits::input_parameter< const CharacterVector& >::type types_(types_SEXP);
-    Rcpp::traits::input_parameter< const unsigned int >::type count_min(count_minSEXP);
-    Rcpp::traits::input_parameter< const IntegerVector >::type sizes_(sizes_SEXP);
-    Rcpp::traits::input_parameter< const String& >::type method(methodSEXP);
-    Rcpp::traits::input_parameter< const double >::type smoothing(smoothingSEXP);
-    rcpp_result_gen = Rcpp::wrap(qatd_cpp_sequences(texts_, types_, count_min, sizes_, method, smoothing));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -322,6 +322,25 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// wordfishcpp
+Rcpp::List wordfishcpp(arma::sp_mat& wfm, IntegerVector& dirvec, NumericVector& priorvec, NumericVector& tolvec, IntegerVector& disptype, NumericVector& dispmin, bool ABS, bool svd_on, double residual_floor);
+RcppExport SEXP quanteda_wordfishcpp(SEXP wfmSEXP, SEXP dirvecSEXP, SEXP priorvecSEXP, SEXP tolvecSEXP, SEXP disptypeSEXP, SEXP dispminSEXP, SEXP ABSSEXP, SEXP svd_onSEXP, SEXP residual_floorSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< arma::sp_mat& >::type wfm(wfmSEXP);
+    Rcpp::traits::input_parameter< IntegerVector& >::type dirvec(dirvecSEXP);
+    Rcpp::traits::input_parameter< NumericVector& >::type priorvec(priorvecSEXP);
+    Rcpp::traits::input_parameter< NumericVector& >::type tolvec(tolvecSEXP);
+    Rcpp::traits::input_parameter< IntegerVector& >::type disptype(disptypeSEXP);
+    Rcpp::traits::input_parameter< NumericVector& >::type dispmin(dispminSEXP);
+    Rcpp::traits::input_parameter< bool >::type ABS(ABSSEXP);
+    Rcpp::traits::input_parameter< bool >::type svd_on(svd_onSEXP);
+    Rcpp::traits::input_parameter< double >::type residual_floor(residual_floorSEXP);
+    rcpp_result_gen = Rcpp::wrap(wordfishcpp(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor));
+    return rcpp_result_gen;
+END_RCPP
+}
 // wordfishcpp_dense
 Rcpp::List wordfishcpp_dense(SEXP wfm, SEXP dir, SEXP priors, SEXP tol, SEXP disp, SEXP dispfloor, bool abs_err);
 RcppExport SEXP quanteda_wordfishcpp_dense(SEXP wfmSEXP, SEXP dirSEXP, SEXP priorsSEXP, SEXP tolSEXP, SEXP dispSEXP, SEXP dispfloorSEXP, SEXP abs_errSEXP) {
@@ -355,25 +374,6 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< bool >::type svd_sparse(svd_sparseSEXP);
     Rcpp::traits::input_parameter< double >::type residual_floor(residual_floorSEXP);
     rcpp_result_gen = Rcpp::wrap(wordfishcpp_mt(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_sparse, residual_floor));
-    return rcpp_result_gen;
-END_RCPP
-}
-// wordfishcpp
-Rcpp::List wordfishcpp(arma::sp_mat& wfm, IntegerVector& dirvec, NumericVector& priorvec, NumericVector& tolvec, IntegerVector& disptype, NumericVector& dispmin, bool ABS, bool svd_on, double residual_floor);
-RcppExport SEXP quanteda_wordfishcpp(SEXP wfmSEXP, SEXP dirvecSEXP, SEXP priorvecSEXP, SEXP tolvecSEXP, SEXP disptypeSEXP, SEXP dispminSEXP, SEXP ABSSEXP, SEXP svd_onSEXP, SEXP residual_floorSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< arma::sp_mat& >::type wfm(wfmSEXP);
-    Rcpp::traits::input_parameter< IntegerVector& >::type dirvec(dirvecSEXP);
-    Rcpp::traits::input_parameter< NumericVector& >::type priorvec(priorvecSEXP);
-    Rcpp::traits::input_parameter< NumericVector& >::type tolvec(tolvecSEXP);
-    Rcpp::traits::input_parameter< IntegerVector& >::type disptype(disptypeSEXP);
-    Rcpp::traits::input_parameter< NumericVector& >::type dispmin(dispminSEXP);
-    Rcpp::traits::input_parameter< bool >::type ABS(ABSSEXP);
-    Rcpp::traits::input_parameter< bool >::type svd_on(svd_onSEXP);
-    Rcpp::traits::input_parameter< double >::type residual_floor(residual_floorSEXP);
-    rcpp_result_gen = Rcpp::wrap(wordfishcpp(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/tests/testthat/test-dfm.R
+++ b/tests/testthat/test-dfm.R
@@ -72,56 +72,6 @@ expect_equal(as.vector(tmp[, c("taxglob", "taxregex", "country")]), c(0, 0, 0, 0
 (tmp <- dfm_lookup(myDfm, myDict, valuetype = "fixed", case_insensitive = FALSE))
 expect_equal(as.vector(tmp[, c("taxglob", "taxregex", "country")]), c(0, 0, 0, 0, 0, 0))
 
-
-test_that("dfm_trim", {
-
-    mycorpus <- corpus_subset(data_corpus_inaugural, Year > 1900 & Year < 2017)
-    preDictDfm <- dfm(mycorpus, remove_punct = TRUE, remove_numbers = TRUE)
-    
-    nfeature(dfm_trim(preDictDfm, min_count = 7))
-    nfeature(dfm_trim(preDictDfm, min_count = 0.001))
-
-    expect_equal(nfeature(dfm_trim(preDictDfm, min_count = 0.001)), 1045)
-    expect_equal(nfeature(dfm_trim(preDictDfm, min_count = 7)), 1045)
-
-    expect_equal(nfeature(dfm_trim(preDictDfm, min_docfreq = 0.05)), 3077)
-    expect_equal(nfeature(dfm_trim(preDictDfm, min_docfreq = 2)), 3077)
-    
-    expect_equal(nfeature(dfm_trim(preDictDfm, sparsity = 0.95)), 3077)
-    expect_equal(nfeature(dfm_trim(preDictDfm, sparsity = 0.95)), nfeature(dfm_trim(preDictDfm, min_docfreq = 0.05)))
-    expect_equal(nfeature(dfm_trim(preDictDfm, min_docfreq = 0.05)), 3077)
-    
-})
-
-test_that("dfm_trim works as expected", {
-    mydfm <- dfm(c("This is a sentence.", "This is a second sentence.", "Third sentence.", "Fouth sentence.", "Fifth sentence."))
-    expect_message(dfm_trim(mydfm, min_count =2, min_docfreq=2, verbose=T),
-                   regexp = "Removing features occurring:")
-    expect_message(dfm_trim(mydfm, min_count =2, min_docfreq=2, verbose=T),
-                   regexp = "fewer than 2 times: 4")
-    expect_message(dfm_trim(mydfm, min_count =2, min_docfreq=2, verbose=T),
-                   regexp = "in fewer than 2 documents: 4")
-    expect_message(dfm_trim(mydfm, min_count =2, min_docfreq=2, verbose=T),
-                   regexp = "  Total features removed: 4 \\(44.4%\\).")
-})
-
-test_that("dfm_trim works as expected", {
-    mydfm <- dfm(c("This is a sentence.", "This is a second sentence.", "Third sentence.", "Fouth sentence.", "Fifth sentence."))
-    expect_message(dfm_trim(mydfm, max_count =2, max_docfreq=2, verbose=T),
-                   regexp = "more than 2 times: 2")
-    expect_message(dfm_trim(mydfm, max_count =2, max_docfreq=2, verbose=T),
-                   regexp = "in more than 2 documents: 2")
-    
-    expect_message(dfm_trim(mydfm, max_count =5, max_docfreq=5, verbose=T),
-                   regexp = "No features removed.")
-})
-
-test_that("dfm_trim works without trimming arguments #509", {
-    mydfm <- dfm(c("This is a sentence.", "This is a second sentence.", "Third sentence."))
-    expect_equal(dim(mydfm[-2, ]), c(2, 7))
-    expect_equal(dim(dfm_trim(mydfm[-2, ], verbose = FALSE)), c(2, 6))
-})
-
 test_that("test c.corpus",
     expect_that(
         matrix(dfm(corpus(c('What does the fox say?', 'What does the fox say?', '')), remove_punct = TRUE)),

--- a/tests/testthat/test-dfm_trim.R
+++ b/tests/testthat/test-dfm_trim.R
@@ -1,0 +1,73 @@
+context("test dfm_trim")
+
+test_that("dfm_trim", {
+    
+    mycorpus <- corpus_subset(data_corpus_inaugural, Year > 1900 & Year < 2017)
+    preDictDfm <- dfm(mycorpus, remove_punct = TRUE, remove_numbers = TRUE)
+    
+    nfeature(dfm_trim(preDictDfm, min_count = 7))
+    nfeature(dfm_trim(preDictDfm, min_count = 0.001))
+    
+    expect_equal(nfeature(dfm_trim(preDictDfm, min_count = 0.001)), 1045)
+    expect_equal(nfeature(dfm_trim(preDictDfm, min_count = 7)), 1045)
+    
+    expect_equal(nfeature(dfm_trim(preDictDfm, min_docfreq = 0.05)), 3077)
+    expect_equal(nfeature(dfm_trim(preDictDfm, min_docfreq = 2)), 3077)
+    
+    expect_equal(nfeature(dfm_trim(preDictDfm, sparsity = 0.95)), 3077)
+    expect_equal(nfeature(dfm_trim(preDictDfm, sparsity = 0.95)), nfeature(dfm_trim(preDictDfm, min_docfreq = 0.05)))
+    expect_equal(nfeature(dfm_trim(preDictDfm, min_docfreq = 0.05)), 3077)
+    
+})
+
+test_that("dfm_trim works as expected", {
+    mydfm <- dfm(c("This is a sentence.", "This is a second sentence.", "Third sentence.", "Fouth sentence.", "Fifth sentence."))
+    expect_message(dfm_trim(mydfm, min_count =2, min_docfreq=2, verbose=T),
+                   regexp = "Removing features occurring:")
+    expect_message(dfm_trim(mydfm, min_count =2, min_docfreq=2, verbose=T),
+                   regexp = "fewer than 2 times: 4")
+    expect_message(dfm_trim(mydfm, min_count =2, min_docfreq=2, verbose=T),
+                   regexp = "in fewer than 2 documents: 4")
+    expect_message(dfm_trim(mydfm, min_count =2, min_docfreq=2, verbose=T),
+                   regexp = "  Total features removed: 4 \\(44.4%\\).")
+})
+
+test_that("dfm_trim works as expected", {
+    mydfm <- dfm(c("This is a sentence.", "This is a second sentence.", "Third sentence.", "Fouth sentence.", "Fifth sentence."))
+    expect_message(dfm_trim(mydfm, max_count =2, max_docfreq=2, verbose=T),
+                   regexp = "more than 2 times: 2")
+    expect_message(dfm_trim(mydfm, max_count =2, max_docfreq=2, verbose=T),
+                   regexp = "in more than 2 documents: 2")
+    
+    expect_message(dfm_trim(mydfm, max_count =5, max_docfreq=5, verbose=T),
+                   regexp = "No features removed.")
+})
+
+test_that("dfm_trim works without trimming arguments #509", {
+    mydfm <- dfm(c("This is a sentence.", "This is a second sentence.", "Third sentence."))
+    expect_equal(dim(mydfm[-2, ]), c(2, 7))
+    expect_equal(dim(dfm_trim(mydfm[-2, ], verbose = FALSE)), c(2, 6))
+})
+
+test_that("dfm_trim doesn't break because of duplicated feature names (#829)", {
+    mydfm <- dfm(c(d1 = "a b c d e", d2 = "a a b b e f", d3 = "b c e e f f f"))
+    colnames(mydfm)[3] <- "b"
+    expect_equal(
+        as.matrix(dfm_trim(mydfm, min_count = 1)),
+        matrix(c(1,1,1,1,1,0, 2,2,0,0,1,1, 0,1,1,0,2,3), byrow = TRUE, nrow = 3,
+               dimnames = list(docs = c("d1", "d2", "d3"), features = c(letters[c(1,2,2,4:6)])))
+    )
+    expect_equal(
+        as.matrix(dfm_trim(mydfm, min_count = 2)),
+        matrix(c(1,1,1,1,0, 2,2,0,1,1, 0,1,1,2,3), byrow = TRUE, nrow = 3,
+               dimnames = list(docs = c("d1", "d2", "d3"), features = c(letters[c(1,2,2,5:6)])))
+    )
+    expect_equal(
+        as.matrix(dfm_trim(mydfm, min_count = 3)),
+        matrix(c(1,1,1,0, 2,2,1,1, 0,1,2,3), byrow = TRUE, nrow = 3,
+               dimnames = list(docs = c("d1", "d2", "d3"), features = c(letters[c(1,2,5:6)])))
+    )
+})
+
+
+

--- a/tests/testthat/test-dfm_weight.R
+++ b/tests/testthat/test-dfm_weight.R
@@ -146,3 +146,16 @@ test_that("tfidf works with different log base", {
         )
     )
 })
+
+test_that("docfreq works when features have duplicated names (#829)", {
+    mydfm <- dfm(c(d1 = "a b c d e", d2 = "a a b b e f", d3 = "b e e f f f"))
+    colnames(mydfm)[3] <- "b"
+    expect_equal(
+        docfreq(mydfm, USE.NAMES = TRUE),
+        c(a=2, b=3, b=1, d=1, e=3, f=2)
+    )
+    expect_equal(
+        docfreq(mydfm, USE.NAMES = FALSE),
+        c(2, 3, 1, 1, 3, 2)
+    )
+})


### PR DESCRIPTION
This bug was actually caused by that problem occurring in `docfreq()`, called by `dfm_trim()`. This fixes the problem and adds tests for both `docfreq()` and `dfm_trim()` for this condition.

Fixes #829