### PR TITLE
Fix #871 print.dfm without loading namespace

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -41,12 +41,12 @@ qatd_cpp_fcm <- function(texts_, n_types, count, window, weights, ordered, tri, 
     .Call(`_quanteda_qatd_cpp_fcm`, texts_, n_types, count, window, weights, ordered, tri, nvec)
 }
 
-qatd_cpp_sequences <- function(texts_, types_, count_min, sizes_, method, smoothing) {
-    .Call(`_quanteda_qatd_cpp_sequences`, texts_, types_, count_min, sizes_, method, smoothing)
-}
-
 qatd_cpp_sequences_old <- function(texts_, words_, types_, count_min, len_max, nested, ordered = FALSE) {
     .Call(`_quanteda_qatd_cpp_sequences_old`, texts_, words_, types_, count_min, len_max, nested, ordered)
+}
+
+qatd_cpp_sequences <- function(texts_, types_, count_min, sizes_, method, smoothing) {
+    .Call(`_quanteda_qatd_cpp_sequences`, texts_, types_, count_min, sizes_, method, smoothing)
 }
 
 qatd_cpp_tokens_compound <- function(texts_, comps_, types_, delim_, join) {
@@ -93,15 +93,15 @@ qatd_cpp_tbb_enabled <- function() {
     .Call(`_quanteda_qatd_cpp_tbb_enabled`)
 }
 
-wordfishcpp <- function(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor) {
-    .Call(`_quanteda_wordfishcpp`, wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor)
-}
-
 wordfishcpp_dense <- function(wfm, dir, priors, tol, disp, dispfloor, abs_err) {
     .Call(`_quanteda_wordfishcpp_dense`, wfm, dir, priors, tol, disp, dispfloor, abs_err)
 }
 
 wordfishcpp_mt <- function(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_sparse, residual_floor) {
     .Call(`_quanteda_wordfishcpp_mt`, wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_sparse, residual_floor)
+}
+
+wordfishcpp <- function(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor) {
+    .Call(`_quanteda_wordfishcpp`, wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor)
 }
 

--- a/R/dfm-print.R
+++ b/R/dfm-print.R
@@ -24,10 +24,7 @@ setMethod("print", signature(x = "dfm"),
                    ndoc = getOption("quanteda_print_dfm_max_ndoc"), 
                    nfeature = getOption("quanteda_print_dfm_max_nfeature"), ...) {
               
-              # if (!length(x)) {
-              #     print(NULL)
-              #     return()
-              # } 
+              quanteda_options(initialize = TRUE)
 
               if (show.summary) {
                   cat("Document-feature matrix of: ",
@@ -47,7 +44,7 @@ setMethod("print", signature(x = "dfm"),
               
               if (show.values == TRUE) {          
                   # if show.values is set to TRUE, show full matrix
-                  ndoc <- nrow(x)
+                  nd <- nrow(x)
                   nfeature <- ncol(x)
               } else if (missing(show.values)) {  
                   if (nrow(x) <= ndoc & ncol(x) <= nfeature) {

--- a/R/dfm-print.R
+++ b/R/dfm-print.R
@@ -59,9 +59,10 @@ setMethod("print", signature(x = "dfm"),
               }
 
               if (show.values)
-                  if (is(x, "sparseMatrix"))
+                  if (is(x, "sparseMatrix")) {
                       Matrix::printSpMatrix2(x[0:ndoc, 0:nfeature], 
                                              col.names = TRUE, zero.print = 0, ...)
+                  }
               else if (is(x, "denseMatrix")) {
                   getMethod("show", "denseMatrix")(x[0:ndoc, 0:nfeature], ...)
               } else {

--- a/R/quanteda-documentation.R
+++ b/R/quanteda-documentation.R
@@ -42,23 +42,28 @@
 #'   "thesaurus", and trimming and weighting features based on document
 #'   frequency, feature frequency, and related measures such as tf-idf.
 #'   
-#'   Once constructed, a \pkg{quanteda} "\link{dfm}"" can be easily analyzed using
+#'   Once constructed, a \pkg{quanteda} document-feature matrix ("\link{dfm}") 
+#'   can be easily analyzed using
 #'   either \pkg{quanteda}'s built-in tools for scaling document positions,
 #'   or used with a number of other text analytic tools, such as: topic models
 #'   (including converters for direct use with the topicmodels, LDA, and stm
 #'   packages) document scaling (using \pkg{quanteda}'s own functions for the
-#'   "wordfish" and "Wordscores" models, direct use with the ca package for
+#'   "wordfish" and "Wordscores" models, direct use with the \strong{ca} 
+#'   package for
 #'   correspondence analysis, or scaling with the austin package) machine
 #'   learning through a variety of other packages that take matrix or
 #'   matrix-like inputs.
 #'   
 #'   Additional features of \pkg{quanteda} include: \itemize{ 
+#'   \item{powerful, flexible tools for working with \link{=dictionary}{dictionaries};}
+#'   \item{the ability to identify \link{=textstat_keyness}{keywords} associated with documents or groups of documents;}
 #'   \item{the ability to explore texts using \link[=kwic]{key-words-in-context};}
 #'   \item{fast computation of a variety of \link[=textstat_readability]{readability indexes};}
 #'   \item{fast computation of a variety of \link[=textstat_lexdiv]{lexical diversity measures};}
-#'   \item{quick computation of word or document \link[=similarity]{similarities}, for clustering or to compute distances for other purposes; and}
+#'   \item{quick computation of word or document \link[=similarity]{similarities}, for clustering or to compute distances for other purposes;}
 #'   \item{a comprehensive suite of \link[=summary.corpus]{descriptive statistics on text} such as the number of sentences, words, characters, or
-#'   syllables per document.}
+#'   syllables per document; and}
+#'   \item{flexible, easy to use graphical tools to portray many of the analyses available in the package.}
 #'   }
 #'   
 #' @section Source code and additional information:

--- a/R/quanteda-documentation.R
+++ b/R/quanteda-documentation.R
@@ -55,8 +55,8 @@
 #'   matrix-like inputs.
 #'   
 #'   Additional features of \pkg{quanteda} include: \itemize{ 
-#'   \item{powerful, flexible tools for working with \link{=dictionary}{dictionaries};}
-#'   \item{the ability to identify \link{=textstat_keyness}{keywords} associated with documents or groups of documents;}
+#'   \item{powerful, flexible tools for working with \link[=dictionary]{dictionaries};}
+#'   \item{the ability to identify \link[=textstat_keyness]{keywords} associated with documents or groups of documents;}
 #'   \item{the ability to explore texts using \link[=kwic]{key-words-in-context};}
 #'   \item{fast computation of a variety of \link[=textstat_readability]{readability indexes};}
 #'   \item{fast computation of a variety of \link[=textstat_lexdiv]{lexical diversity measures};}

--- a/R/tokens.R
+++ b/R/tokens.R
@@ -322,6 +322,7 @@ as.tokens.list <- function(x, concatenator = '_') {
     result <- tokens_hash(x)
     attr(result, "what") <- "word"
     attr(result, "ngrams") <- 1L
+    attr(result, "skip") <- 0L
     attr(result, "concatenator") <- concatenator
     attr(result, 'padding') <- FALSE
     class(result)[2] <- "tokenizedTexts"

--- a/R/tokens.R
+++ b/R/tokens.R
@@ -274,6 +274,7 @@ tokens.character <- function(x, what = c("word", "sentence", "character", "faste
     names(result) <- names_org
     attr(result, "what") <- what
     attr(result, "ngrams") <- ngrams
+    attr(result, "skip") <- skip
     attr(result, "concatenator") <- concatenator
     attr(result, 'padding') <- FALSE
     

--- a/man/quanteda-package.Rd
+++ b/man/quanteda-package.Rd
@@ -61,8 +61,8 @@ methods.
   matrix-like inputs.
   
   Additional features of \pkg{quanteda} include: \itemize{ 
-  \item{powerful, flexible tools for working with \link{=dictionary}{dictionaries};}
-  \item{the ability to identify \link{=textstat_keyness}{keywords} associated with documents or groups of documents;}
+  \item{powerful, flexible tools for working with \link[=dictionary]{dictionaries};}
+  \item{the ability to identify \link[=textstat_keyness]{keywords} associated with documents or groups of documents;}
   \item{the ability to explore texts using \link[=kwic]{key-words-in-context};}
   \item{fast computation of a variety of \link[=textstat_readability]{readability indexes};}
   \item{fast computation of a variety of \link[=textstat_lexdiv]{lexical diversity measures};}

--- a/man/quanteda-package.Rd
+++ b/man/quanteda-package.Rd
@@ -48,23 +48,28 @@ methods.
   "thesaurus", and trimming and weighting features based on document
   frequency, feature frequency, and related measures such as tf-idf.
   
-  Once constructed, a \pkg{quanteda} "\link{dfm}"" can be easily analyzed using
+  Once constructed, a \pkg{quanteda} document-feature matrix ("\link{dfm}") 
+  can be easily analyzed using
   either \pkg{quanteda}'s built-in tools for scaling document positions,
   or used with a number of other text analytic tools, such as: topic models
   (including converters for direct use with the topicmodels, LDA, and stm
   packages) document scaling (using \pkg{quanteda}'s own functions for the
-  "wordfish" and "Wordscores" models, direct use with the ca package for
+  "wordfish" and "Wordscores" models, direct use with the \strong{ca} 
+  package for
   correspondence analysis, or scaling with the austin package) machine
   learning through a variety of other packages that take matrix or
   matrix-like inputs.
   
   Additional features of \pkg{quanteda} include: \itemize{ 
+  \item{powerful, flexible tools for working with \link{=dictionary}{dictionaries};}
+  \item{the ability to identify \link{=textstat_keyness}{keywords} associated with documents or groups of documents;}
   \item{the ability to explore texts using \link[=kwic]{key-words-in-context};}
   \item{fast computation of a variety of \link[=textstat_readability]{readability indexes};}
   \item{fast computation of a variety of \link[=textstat_lexdiv]{lexical diversity measures};}
-  \item{quick computation of word or document \link[=similarity]{similarities}, for clustering or to compute distances for other purposes; and}
+  \item{quick computation of word or document \link[=similarity]{similarities}, for clustering or to compute distances for other purposes;}
   \item{a comprehensive suite of \link[=summary.corpus]{descriptive statistics on text} such as the number of sentences, words, characters, or
-  syllables per document.}
+  syllables per document; and}
+  \item{flexible, easy to use graphical tools to portray many of the analyses available in the package.}
   }
 }
 \section{Source code and additional information}{

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -139,22 +139,6 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// qatd_cpp_sequences
-DataFrame qatd_cpp_sequences(const List& texts_, const CharacterVector& types_, const unsigned int count_min, const IntegerVector sizes_, const String& method, const double smoothing);
-RcppExport SEXP _quanteda_qatd_cpp_sequences(SEXP texts_SEXP, SEXP types_SEXP, SEXP count_minSEXP, SEXP sizes_SEXP, SEXP methodSEXP, SEXP smoothingSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const List& >::type texts_(texts_SEXP);
-    Rcpp::traits::input_parameter< const CharacterVector& >::type types_(types_SEXP);
-    Rcpp::traits::input_parameter< const unsigned int >::type count_min(count_minSEXP);
-    Rcpp::traits::input_parameter< const IntegerVector >::type sizes_(sizes_SEXP);
-    Rcpp::traits::input_parameter< const String& >::type method(methodSEXP);
-    Rcpp::traits::input_parameter< const double >::type smoothing(smoothingSEXP);
-    rcpp_result_gen = Rcpp::wrap(qatd_cpp_sequences(texts_, types_, count_min, sizes_, method, smoothing));
-    return rcpp_result_gen;
-END_RCPP
-}
 // qatd_cpp_sequences_old
 DataFrame qatd_cpp_sequences_old(const List& texts_, const IntegerVector& words_, const CharacterVector& types_, const unsigned int count_min, unsigned int len_max, bool nested, bool ordered);
 RcppExport SEXP _quanteda_qatd_cpp_sequences_old(SEXP texts_SEXP, SEXP words_SEXP, SEXP types_SEXP, SEXP count_minSEXP, SEXP len_maxSEXP, SEXP nestedSEXP, SEXP orderedSEXP) {
@@ -169,6 +153,22 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< bool >::type nested(nestedSEXP);
     Rcpp::traits::input_parameter< bool >::type ordered(orderedSEXP);
     rcpp_result_gen = Rcpp::wrap(qatd_cpp_sequences_old(texts_, words_, types_, count_min, len_max, nested, ordered));
+    return rcpp_result_gen;
+END_RCPP
+}
+// qatd_cpp_sequences
+DataFrame qatd_cpp_sequences(const List& texts_, const CharacterVector& types_, const unsigned int count_min, const IntegerVector sizes_, const String& method, const double smoothing);
+RcppExport SEXP _quanteda_qatd_cpp_sequences(SEXP texts_SEXP, SEXP types_SEXP, SEXP count_minSEXP, SEXP sizes_SEXP, SEXP methodSEXP, SEXP smoothingSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const List& >::type texts_(texts_SEXP);
+    Rcpp::traits::input_parameter< const CharacterVector& >::type types_(types_SEXP);
+    Rcpp::traits::input_parameter< const unsigned int >::type count_min(count_minSEXP);
+    Rcpp::traits::input_parameter< const IntegerVector >::type sizes_(sizes_SEXP);
+    Rcpp::traits::input_parameter< const String& >::type method(methodSEXP);
+    Rcpp::traits::input_parameter< const double >::type smoothing(smoothingSEXP);
+    rcpp_result_gen = Rcpp::wrap(qatd_cpp_sequences(texts_, types_, count_min, sizes_, method, smoothing));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -322,25 +322,6 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// wordfishcpp
-Rcpp::List wordfishcpp(arma::sp_mat& wfm, IntegerVector& dirvec, NumericVector& priorvec, NumericVector& tolvec, IntegerVector& disptype, NumericVector& dispmin, bool ABS, bool svd_on, double residual_floor);
-RcppExport SEXP _quanteda_wordfishcpp(SEXP wfmSEXP, SEXP dirvecSEXP, SEXP priorvecSEXP, SEXP tolvecSEXP, SEXP disptypeSEXP, SEXP dispminSEXP, SEXP ABSSEXP, SEXP svd_onSEXP, SEXP residual_floorSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< arma::sp_mat& >::type wfm(wfmSEXP);
-    Rcpp::traits::input_parameter< IntegerVector& >::type dirvec(dirvecSEXP);
-    Rcpp::traits::input_parameter< NumericVector& >::type priorvec(priorvecSEXP);
-    Rcpp::traits::input_parameter< NumericVector& >::type tolvec(tolvecSEXP);
-    Rcpp::traits::input_parameter< IntegerVector& >::type disptype(disptypeSEXP);
-    Rcpp::traits::input_parameter< NumericVector& >::type dispmin(dispminSEXP);
-    Rcpp::traits::input_parameter< bool >::type ABS(ABSSEXP);
-    Rcpp::traits::input_parameter< bool >::type svd_on(svd_onSEXP);
-    Rcpp::traits::input_parameter< double >::type residual_floor(residual_floorSEXP);
-    rcpp_result_gen = Rcpp::wrap(wordfishcpp(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor));
-    return rcpp_result_gen;
-END_RCPP
-}
 // wordfishcpp_dense
 Rcpp::List wordfishcpp_dense(SEXP wfm, SEXP dir, SEXP priors, SEXP tol, SEXP disp, SEXP dispfloor, bool abs_err);
 RcppExport SEXP _quanteda_wordfishcpp_dense(SEXP wfmSEXP, SEXP dirSEXP, SEXP priorsSEXP, SEXP tolSEXP, SEXP dispSEXP, SEXP dispfloorSEXP, SEXP abs_errSEXP) {
@@ -374,6 +355,25 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< bool >::type svd_sparse(svd_sparseSEXP);
     Rcpp::traits::input_parameter< double >::type residual_floor(residual_floorSEXP);
     rcpp_result_gen = Rcpp::wrap(wordfishcpp_mt(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_sparse, residual_floor));
+    return rcpp_result_gen;
+END_RCPP
+}
+// wordfishcpp
+Rcpp::List wordfishcpp(arma::sp_mat& wfm, IntegerVector& dirvec, NumericVector& priorvec, NumericVector& tolvec, IntegerVector& disptype, NumericVector& dispmin, bool ABS, bool svd_on, double residual_floor);
+RcppExport SEXP _quanteda_wordfishcpp(SEXP wfmSEXP, SEXP dirvecSEXP, SEXP priorvecSEXP, SEXP tolvecSEXP, SEXP disptypeSEXP, SEXP dispminSEXP, SEXP ABSSEXP, SEXP svd_onSEXP, SEXP residual_floorSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< arma::sp_mat& >::type wfm(wfmSEXP);
+    Rcpp::traits::input_parameter< IntegerVector& >::type dirvec(dirvecSEXP);
+    Rcpp::traits::input_parameter< NumericVector& >::type priorvec(priorvecSEXP);
+    Rcpp::traits::input_parameter< NumericVector& >::type tolvec(tolvecSEXP);
+    Rcpp::traits::input_parameter< IntegerVector& >::type disptype(disptypeSEXP);
+    Rcpp::traits::input_parameter< NumericVector& >::type dispmin(dispminSEXP);
+    Rcpp::traits::input_parameter< bool >::type ABS(ABSSEXP);
+    Rcpp::traits::input_parameter< bool >::type svd_on(svd_onSEXP);
+    Rcpp::traits::input_parameter< double >::type residual_floor(residual_floorSEXP);
+    rcpp_result_gen = Rcpp::wrap(wordfishcpp(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/tests/testthat/test-dfm.R
+++ b/tests/testthat/test-dfm.R
@@ -355,7 +355,7 @@ test_that("dfm print works with options as expected", {
     )
     expect_output(
         print(tmp[1:3, 1:3], ndoc = 2, nfeature = 2, show.values = TRUE),
-        "^Document-feature matrix of: 3 documents, 3 features.*3 x 3 sparse Matrix.*features"
+        "^Document-feature matrix of: 3 documents, 3 features.*2 x 3 sparse Matrix.*features"
     )
     expect_output(
         print(tmp[1:3, 1:3], ndoc = 2, nfeature = 2),

--- a/tests/testthat/test-dfm.R
+++ b/tests/testthat/test-dfm.R
@@ -355,7 +355,7 @@ test_that("dfm print works with options as expected", {
     )
     expect_output(
         print(tmp[1:3, 1:3], ndoc = 2, nfeature = 2, show.values = TRUE),
-        "^Document-feature matrix of: 3 documents, 3 features.*3 x 3 sparse Matrix"
+        "^Document-feature matrix of: 3 documents, 3 features.*3 x 3 sparse Matrix.*features"
     )
     expect_output(
         print(tmp[1:3, 1:3], ndoc = 2, nfeature = 2),


### PR DESCRIPTION
Fixes #871, when dfm.print is called without `package:quanteda` being loaded.

Also adds the skip attribute being set when tokens are created.