### PR TITLE
Improve cbind functions for dfm and conformable objects

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -41,12 +41,12 @@ qatd_cpp_fcm <- function(texts_, n_types, count, window, weights, ordered, tri, 
     .Call(`_quanteda_qatd_cpp_fcm`, texts_, n_types, count, window, weights, ordered, tri, nvec)
 }
 
-qatd_cpp_sequences <- function(texts_, types_, count_min, sizes_, method, smoothing) {
-    .Call(`_quanteda_qatd_cpp_sequences`, texts_, types_, count_min, sizes_, method, smoothing)
-}
-
 qatd_cpp_sequences_old <- function(texts_, words_, types_, count_min, len_max, nested, ordered = FALSE) {
     .Call(`_quanteda_qatd_cpp_sequences_old`, texts_, words_, types_, count_min, len_max, nested, ordered)
+}
+
+qatd_cpp_sequences <- function(texts_, types_, count_min, sizes_, method, smoothing) {
+    .Call(`_quanteda_qatd_cpp_sequences`, texts_, types_, count_min, sizes_, method, smoothing)
 }
 
 qatd_cpp_tokens_compound <- function(texts_, comps_, types_, delim_, join) {
@@ -93,15 +93,15 @@ qatd_cpp_tbb_enabled <- function() {
     .Call(`_quanteda_qatd_cpp_tbb_enabled`)
 }
 
-wordfishcpp <- function(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor) {
-    .Call(`_quanteda_wordfishcpp`, wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor)
-}
-
 wordfishcpp_dense <- function(wfm, dir, priors, tol, disp, dispfloor, abs_err) {
     .Call(`_quanteda_wordfishcpp_dense`, wfm, dir, priors, tol, disp, dispfloor, abs_err)
 }
 
 wordfishcpp_mt <- function(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_sparse, residual_floor) {
     .Call(`_quanteda_wordfishcpp_mt`, wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_sparse, residual_floor)
+}
+
+wordfishcpp <- function(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor) {
+    .Call(`_quanteda_wordfishcpp`, wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor)
 }
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -41,12 +41,12 @@ qatd_cpp_fcm <- function(texts_, n_types, count, window, weights, ordered, tri, 
     .Call(`_quanteda_qatd_cpp_fcm`, texts_, n_types, count, window, weights, ordered, tri, nvec)
 }
 
-qatd_cpp_sequences_old <- function(texts_, words_, types_, count_min, len_max, nested, ordered = FALSE) {
-    .Call(`_quanteda_qatd_cpp_sequences_old`, texts_, words_, types_, count_min, len_max, nested, ordered)
-}
-
 qatd_cpp_sequences <- function(texts_, types_, count_min, sizes_, method, smoothing) {
     .Call(`_quanteda_qatd_cpp_sequences`, texts_, types_, count_min, sizes_, method, smoothing)
+}
+
+qatd_cpp_sequences_old <- function(texts_, words_, types_, count_min, len_max, nested, ordered = FALSE) {
+    .Call(`_quanteda_qatd_cpp_sequences_old`, texts_, words_, types_, count_min, len_max, nested, ordered)
 }
 
 qatd_cpp_tokens_compound <- function(texts_, comps_, types_, delim_, join) {
@@ -93,15 +93,15 @@ qatd_cpp_tbb_enabled <- function() {
     .Call(`_quanteda_qatd_cpp_tbb_enabled`)
 }
 
+wordfishcpp <- function(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor) {
+    .Call(`_quanteda_wordfishcpp`, wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor)
+}
+
 wordfishcpp_dense <- function(wfm, dir, priors, tol, disp, dispfloor, abs_err) {
     .Call(`_quanteda_wordfishcpp_dense`, wfm, dir, priors, tol, disp, dispfloor, abs_err)
 }
 
 wordfishcpp_mt <- function(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_sparse, residual_floor) {
     .Call(`_quanteda_wordfishcpp_mt`, wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_sparse, residual_floor)
-}
-
-wordfishcpp <- function(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor) {
-    .Call(`_quanteda_wordfishcpp`, wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor)
 }
 

--- a/R/character-methods.R
+++ b/R/character-methods.R
@@ -10,7 +10,7 @@
 summary.character <- function(object, n = 100, verbose = TRUE, tolower = FALSE, ...) {
     object <- object[1 : min(c(n, length(object)))]
     if (is.null(names(object))) 
-        names(object) <- paste(quanteda_options("docname_stem"), seq_along(object), sep = "")
+        names(object) <- paste(quanteda_options("base_docname"), seq_along(object), sep = "")
     nsents  <- nsentence(object, ...)
     if (tolower) object <- char_tolower(object)
     toks <- tokens(object, ...)

--- a/R/character-methods.R
+++ b/R/character-methods.R
@@ -10,7 +10,7 @@
 summary.character <- function(object, n = 100, verbose = TRUE, tolower = FALSE, ...) {
     object <- object[1 : min(c(n, length(object)))]
     if (is.null(names(object))) 
-        names(object) <- paste("text", seq_along(object), sep = "")
+        names(object) <- paste(quanteda_options("docname_stem"), seq_along(object), sep = "")
     nsents  <- nsentence(object, ...)
     if (tolower) object <- char_tolower(object)
     toks <- tokens(object, ...)

--- a/R/corpus.R
+++ b/R/corpus.R
@@ -156,7 +156,7 @@ corpus.character <- function(x, docnames = NULL, docvars = NULL, metacorpus = NU
         stopifnot(length(docnames) == length(x))
         names(x) <- docnames
     } else if (is.null(x_names)) {
-        names(x) <- paste("text", seq_along(x), sep="")
+        names(x) <- paste(quanteda_options("docname_stem"), seq_along(x), sep="")
     } else if (is.null(names(x))) {
         # if they previously existed, but got obliterated by a stringi function
         names(x) <- x_names

--- a/R/corpus.R
+++ b/R/corpus.R
@@ -156,7 +156,7 @@ corpus.character <- function(x, docnames = NULL, docvars = NULL, metacorpus = NU
         stopifnot(length(docnames) == length(x))
         names(x) <- docnames
     } else if (is.null(x_names)) {
-        names(x) <- paste(quanteda_options("docname_stem"), seq_along(x), sep="")
+        names(x) <- paste(quanteda_options("base_docname"), seq_along(x), sep="")
     } else if (is.null(names(x))) {
         # if they previously existed, but got obliterated by a stringi function
         names(x) <- x_names

--- a/R/dfm-classes.R
+++ b/R/dfm-classes.R
@@ -224,20 +224,20 @@ cbind.dfm <- function(...) {
     names <- names(args)
     
     x <- args[[1]]
+    y <- args[[2]]
+    if (!(is.dfm(x) || is.dfm(y))) stop("cannot cbind this type of object")
+
     if (is.matrix(x)) {
         x <- as.dfm(x)
     } else if (is.numeric(x)) {
-        x <- as.dfm(matrix(x, ncol = 1, nrow = length(x), dimnames = list(NULL, names[1])))
+        x <- as.dfm(matrix(x, ncol = 1, nrow = nrow(y), dimnames = list(NULL, names[1])))
     }
     
-    y <- args[[2]]
     if (is.matrix(y)) {
         y <- as.dfm(y)
     } else if (is.numeric(y)) {
-        y <- as.dfm(matrix(y, ncol = 1, nrow = length(y), dimnames = list(NULL, names[2])))
+        y <- as.dfm(matrix(y, ncol = 1, nrow = nrow(x), dimnames = list(NULL, names[2])))
     }
-    
-    if (!(is.dfm(x) && is.dfm(y))) stop("cannot cbind this type of object")
     
     result <- quanteda:::cbind_dfm_dfm(x, y)
     
@@ -267,7 +267,7 @@ cbind_dfm_dfm <- function(...) {
 
     # make any added feature names unique
     dupl_featname_index <- 
-        grep(paste0("^", quanteda_options("featname_stem")), colnames(result))
+        grep(paste0("^", quanteda_options("base_featname")), colnames(result))
     colnames(result)[dupl_featname_index] <- make.unique(gsub("\\d", "", colnames(result)[dupl_featname_index]), "")
     # only issue warning if these did not come from added feature names
     if (any(duplicated(colnames(result))))

--- a/R/dfm-classes.R
+++ b/R/dfm-classes.R
@@ -239,7 +239,7 @@ cbind.dfm <- function(...) {
         y <- as.dfm(matrix(y, ncol = 1, nrow = nrow(x), dimnames = list(NULL, names[2])))
     }
     
-    result <- quanteda:::cbind_dfm_dfm(x, y)
+    result <- cbind_dfm_dfm(x, y)
     
     while (length(args[-c(1,2)])) {
         args <- args[-c(1,2)]

--- a/R/dfm-classes.R
+++ b/R/dfm-classes.R
@@ -222,10 +222,10 @@ as.data.frame.dfm <- function(x, row.names = NULL, ...) {
 cbind.dfm <- function(...) {
     args <- list(...)
     names <- names(args)
-    
+    if (!any(sapply(args, is.dfm))) stop("at least one input object must be a dfm")
+
     x <- args[[1]]
     y <- args[[2]]
-    if (!(is.dfm(x) || is.dfm(y))) stop("cannot cbind this type of object")
 
     if (is.matrix(x)) {
         x <- as.dfm(x)

--- a/R/dfm-classes.R
+++ b/R/dfm-classes.R
@@ -219,44 +219,34 @@ as.data.frame.dfm <- function(x, row.names = NULL, ...) {
 #' cbind(dfm1, matrix(c(101, 102), ncol = 1))
 #' cbind(matrix(c(101, 102), ncol = 1), dfm1)
 #' 
-cbind.dfm <-  function(...) {
+cbind.dfm <- function(...) {
     args <- list(...)
-    result <- cbind_dfm(args[[1]], args[[2]])
-    for (a in args[-c(1,2)]) {
-        result <- cbind_dfm(result, a)
+    names <- names(args)
+    
+    x <- args[[1]]
+    if (is.matrix(x)) {
+        x <- as.dfm(x)
+    } else if (is.numeric(x)) {
+        x <- as.dfm(matrix(x, ncol = 1, nrow = length(x), dimnames = list(NULL, names[1])))
+    }
+    
+    y <- args[[2]]
+    if (is.matrix(y)) {
+        y <- as.dfm(y)
+    } else if (is.numeric(y)) {
+        y <- as.dfm(matrix(y, ncol = 1, nrow = length(y), dimnames = list(NULL, names[2])))
+    }
+    
+    if (!(is.dfm(x) && is.dfm(y))) stop("cannot cbind this type of object")
+    
+    result <- quanteda:::cbind_dfm_dfm(x, y)
+    
+    while (length(args[-c(1,2)])) {
+        args <- args[-c(1,2)]
+        result <- do.call(cbind, c(result, args))
     }
     result
 }
-
-setGeneric("cbind_dfm", function(x, y, ...) standardGeneric("cbind_dfm"))
-
-setMethod("cbind_dfm", signature(x = "dfm", y = "dfm"), function(x, y, ...) {
-    cbind_dfm_dfm(x, y, ...)
-})
-
-setMethod("cbind_dfm", signature(x = "dfm", y = "numeric"), function(x, y, ...) {
-    if (is.null(names(y))) fname <- quanteda_options("featname_stem")
-    y <- as.dfm(matrix(y, ncol = 1, nrow = ndoc(x), dimnames = list(docnames(x), fname)))
-    cbind_dfm_dfm(x, y, ...)
-})
-
-setMethod("cbind_dfm", signature(x = "numeric", y = "dfm"), function(x, y, ...) {
-    if (is.null(names(x))) fname <- quanteda_options("featname_stem")
-    x <- as.dfm(matrix(x, ncol = 1, nrow = ndoc(y), dimnames = list(docnames(y), fname)))
-    cbind_dfm_dfm(x, y, ...)
-})
-
-setMethod("cbind_dfm", signature(x = "dfm", y = "matrix"), function(x, y, ...) {
-    if (is.null(colnames(y))) colnames(y) <- paste0(quanteda_options("featname_stem"), 1:ncol(y))
-    if (is.null(rownames(y))) rownames(y) <- docnames(x)
-    cbind_dfm_dfm(x, as.dfm(y), ...)
-})
-
-setMethod("cbind_dfm", signature(x = "matrix", y = "dfm"), function(x, y, ...) {
-    if (is.null(colnames(x))) colnames(x) <- paste0(quanteda_options("featname_stem"), 1:ncol(x))
-    if (is.null(rownames(x))) rownames(x) <- docnames(y)
-    cbind_dfm_dfm(as.dfm(x), y, ...)
-})
 
 cbind_dfm_dfm <- function(...) {
     args <- list(...)

--- a/R/dfm-methods.R
+++ b/R/dfm-methods.R
@@ -110,8 +110,8 @@ as.dfm.data.frame <- function(x) {
 as_dfm_constructor <- function(x) {
     new("dfmSparse", Matrix(as.matrix(x), 
                             sparse = TRUE,
-                            dimnames = list(docs = if (is.null(rownames(x))) paste0("doc", seq_len(nrow(x))) else rownames(x),
-                                            features = if (is.null(colnames(x))) paste0("feat", seq_len(ncol(x))) else colnames(x)) 
+                            dimnames = list(docs = if (is.null(rownames(x))) paste0(quanteda_options("docname_stem"), seq_len(nrow(x))) else rownames(x),
+                                            features = if (is.null(colnames(x))) paste0(quanteda_options("featname_stem"), seq_len(ncol(x))) else colnames(x)) 
                             ) 
         )
 }

--- a/R/dfm-methods.R
+++ b/R/dfm-methods.R
@@ -110,8 +110,8 @@ as.dfm.data.frame <- function(x) {
 as_dfm_constructor <- function(x) {
     new("dfmSparse", Matrix(as.matrix(x), 
                             sparse = TRUE,
-                            dimnames = list(docs = if (is.null(rownames(x))) paste0(quanteda_options("docname_stem"), seq_len(nrow(x))) else rownames(x),
-                                            features = if (is.null(colnames(x))) paste0(quanteda_options("featname_stem"), seq_len(ncol(x))) else colnames(x)) 
+                            dimnames = list(docs = if (is.null(rownames(x))) paste0(quanteda_options("base_docname"), seq_len(nrow(x))) else rownames(x),
+                                            features = if (is.null(colnames(x))) paste0(quanteda_options("base_featname"), seq_len(ncol(x))) else colnames(x)) 
                             ) 
         )
 }

--- a/R/dfm.R
+++ b/R/dfm.R
@@ -233,7 +233,7 @@ dfm.tokenizedTexts <- function(x,
     
     # set document names if none
     if (is.null(names(x))) {
-        names(x) <- paste("text", seq_along(x), sep="")
+        names(x) <- paste0(quanteda_options("docname_stem"), seq_along(x))
     } 
 
     if (verbose) {

--- a/R/dfm.R
+++ b/R/dfm.R
@@ -233,7 +233,7 @@ dfm.tokenizedTexts <- function(x,
     
     # set document names if none
     if (is.null(names(x))) {
-        names(x) <- paste0(quanteda_options("docname_stem"), seq_along(x))
+        names(x) <- paste0(quanteda_options("base_docname"), seq_along(x))
     } 
 
     if (verbose) {

--- a/R/kwic.R
+++ b/R/kwic.R
@@ -102,7 +102,7 @@ kwic.tokens <- function(x, pattern, window = 5, valuetype = c("glob", "regex", "
     
     # add document names if none
     if (is.null(names(x))) {
-        names(x) <- paste0(quanteda_options("docname_stem"), seq_len(x))
+        names(x) <- paste0(quanteda_options("base_docname"), seq_len(x))
     }
     
     keywords_id <- features2id(pattern, types, valuetype, case_insensitive, attr(x, 'concatenator'))

--- a/R/kwic.R
+++ b/R/kwic.R
@@ -102,7 +102,7 @@ kwic.tokens <- function(x, pattern, window = 5, valuetype = c("glob", "regex", "
     
     # add document names if none
     if (is.null(names(x))) {
-        names(x) <- paste("text", 1:length(x), sep="")
+        names(x) <- paste0(quanteda_options("docname_stem"), seq_len(x))
     }
     
     keywords_id <- features2id(pattern, types, valuetype, case_insensitive, attr(x, 'concatenator'))

--- a/R/quanteda_options.R
+++ b/R/quanteda_options.R
@@ -3,8 +3,8 @@ QUANTEDA_OPTION_LIST <- list(quanteda_threads = max(1L, floor(RcppParallel::defa
                              quanteda_verbose = FALSE,
                              quanteda_print_dfm_max_ndoc = 20L,
                              quanteda_print_dfm_max_nfeature = 20L,
-                             quanteda_docname_stem = "text",
-                             quanteda_featname_stem = "feat")
+                             quanteda_base_docname = "text",
+                             quanteda_base_featname = "feat")
 
 
 #' get or set package options for quanteda
@@ -29,9 +29,8 @@ QUANTEDA_OPTION_LIST <- list(quanteda_threads = max(1L, floor(RcppParallel::defa
 #'    to display when using the defaults for printing a dfm}
 #' \item{\code{print_dfm_max_nfeature}}{integer; specifies the number of features
 #'    to display when using the defaults for printing a dfm}
-#' \item{\code{docname_stem}}{character; stem name for documents that are unnamed
+#' \item{\code{base_docname}}{character; stem name for documents that are unnamed
 #'    when a corpus, tokens, or dfm are created}
-#' \item{\code{featname_stem}}{character; stem name for features that are unnamed
 #'    when dfm is converted from another object}
 #' }
 #' @return 

--- a/R/quanteda_options.R
+++ b/R/quanteda_options.R
@@ -2,7 +2,9 @@
 QUANTEDA_OPTION_LIST <- list(quanteda_threads = max(1L, floor(RcppParallel::defaultNumThreads() / 2)),
                              quanteda_verbose = FALSE,
                              quanteda_print_dfm_max_ndoc = 20L,
-                             quanteda_print_dfm_max_nfeature = 20L)
+                             quanteda_print_dfm_max_nfeature = 20L,
+                             quanteda_docname_stem = "text",
+                             quanteda_featname_stem = "feat")
 
 
 #' get or set package options for quanteda
@@ -27,6 +29,10 @@ QUANTEDA_OPTION_LIST <- list(quanteda_threads = max(1L, floor(RcppParallel::defa
 #'    to display when using the defaults for printing a dfm}
 #' \item{\code{print_dfm_max_nfeature}}{integer; specifies the number of features
 #'    to display when using the defaults for printing a dfm}
+#' \item{\code{docname_stem}}{character; stem name for documents that are unnamed
+#'    when a corpus, tokens, or dfm are created}
+#' \item{\code{featname_stem}}{character; stem name for features that are unnamed
+#'    when dfm is converted from another object}
 #' }
 #' @return 
 #'   When called using a \code{key = value} pair (where \code{key} can be a label or 

--- a/R/quanteda_options.R
+++ b/R/quanteda_options.R
@@ -10,14 +10,14 @@ QUANTEDA_OPTION_LIST <- list(quanteda_threads = max(1L, floor(RcppParallel::defa
 #' get or set package options for quanteda
 #' 
 #' Get or set global options affecting functions across \pkg{quanteda}.
-#' @param ... options to be set, as key-value pair, same as \code{\link{options}}. 
-#'   This may be a list of valid key-value pairs, useful for setting a group of
-#'   options at once (see examples).
-#' @param reset logical; if \code{TRUE}, reset all \pkg{quanteda} options to their 
-#'   default values
-#' @param initialize logical; if \code{TRUE}, reset only the \pkg{quanteda} options 
-#'   that are not already defined.  Used for setting initial values when some have 
-#'   been defined previously, such as in `.Rprofile`.
+#' @param ... options to be set, as key-value pair, same as
+#'   \code{\link{options}}. This may be a list of valid key-value pairs, useful
+#'   for setting a group of options at once (see examples).
+#' @param reset logical; if \code{TRUE}, reset all \pkg{quanteda} options to
+#'   their default values
+#' @param initialize logical; if \code{TRUE}, reset only the \pkg{quanteda}
+#'   options that are not already defined.  Used for setting initial values when
+#'   some have been defined previously, such as in `.Rprofile`.
 #' @details
 #' Currently available options are:
 #' \describe{
@@ -29,9 +29,9 @@ QUANTEDA_OPTION_LIST <- list(quanteda_threads = max(1L, floor(RcppParallel::defa
 #'    to display when using the defaults for printing a dfm}
 #' \item{\code{print_dfm_max_nfeature}}{integer; specifies the number of features
 #'    to display when using the defaults for printing a dfm}
-#' \item{\code{base_docname}}{character; stem name for documents that are unnamed
-#'    when a corpus, tokens, or dfm are created}
-#'    when dfm is converted from another object}
+#' \item{\code{base_docname}}{character; stem name for documents that are
+#' unnamed when a corpus, tokens, or dfm are created or when a dfm is converted
+#' from another object}
 #' }
 #' @return 
 #'   When called using a \code{key = value} pair (where \code{key} can be a label or 

--- a/R/textstat_readability.R
+++ b/R/textstat_readability.R
@@ -148,7 +148,7 @@ textstat_readability.character <- function(x,
         Coleman.Liau <- meanSentenceLength <- meanWordSyllables <- NULL
 
     if (is.null(names(x)))
-        names(x) <- paste0("text", seq_along(x))
+        names(x) <- paste0(quanteda_options("docname_stem"), seq_along(x))
 
     if (!missing(min_sentence_length) | !missing(max_sentence_length)) {
         x <- char_trim(x, 'sentences',

--- a/R/textstat_readability.R
+++ b/R/textstat_readability.R
@@ -148,7 +148,7 @@ textstat_readability.character <- function(x,
         Coleman.Liau <- meanSentenceLength <- meanWordSyllables <- NULL
 
     if (is.null(names(x)))
-        names(x) <- paste0(quanteda_options("docname_stem"), seq_along(x))
+        names(x) <- paste0(quanteda_options("base_docname"), seq_along(x))
 
     if (!missing(min_sentence_length) | !missing(max_sentence_length)) {
         x <- char_trim(x, 'sentences',

--- a/man/cbind.dfm.Rd
+++ b/man/cbind.dfm.Rd
@@ -44,6 +44,7 @@ cbind(100, dfm1)
 cbind(dfm1, matrix(c(101, 102), ncol = 1))
 cbind(matrix(c(101, 102), ncol = 1), dfm1)
 
+
 # rbind() for dfm objects
 (dfm1 <- dfm(c(doc1 = "This is one sample text sample."), verbose = FALSE))
 (dfm2 <- dfm(c(doc2 = "One two three text text."), verbose = FALSE))

--- a/man/cbind.dfm.Rd
+++ b/man/cbind.dfm.Rd
@@ -10,20 +10,22 @@
 \method{rbind}{dfm}(...)
 }
 \arguments{
-\item{...}{\link{dfm} objects to be joined column-wise (\code{cbind}) or
-row-wise (\code{rbind}) to the first}
+\item{...}{\link{dfm}, numeric, or matrix  objects to be joined column-wise
+(\code{cbind}) or row-wise (\code{rbind}) to the first.  Numeric objects
+not confirming to the row or column dimension will be recycled as normal.}
 }
 \description{
-Take a sequence of \link{dfm} objects and combine by columns or
-rows, returning a dfm with the combined documents or features, respectively.
+Combine a \link{dfm} with another dfm, or numeric, or matrix object, 
+returning a dfm with the combined documents or features, respectively.
 }
 \details{
 \code{cbind(x, y, ...)} combines dfm objects by columns, returning a
-  dfm object with combined features from input dfm objects.  Note that this should be used
-  with extreme caution, as joining dfms with different documents will result in a new row
-  with the docname(s) of the first dfm, merging in those from the second.  Furthermore, 
-  if features are shared between the dfms being cbinded, then duplicate feature labels will 
-  result.  In both instances, warning messages will result.
+  dfm object with combined features from input dfm objects.  Note that this 
+  should be used with extreme caution, as joining dfms with different 
+  documents will result in a new row with the docname(s) of the first dfm, 
+  merging in those from the second.  Furthermore, if features are shared 
+  between the dfms being cbinded, then duplicate feature labels will result. 
+  In both instances, warning messages will result.
 
 \code{rbind(x, y, ...)} combines dfm objects by rows, returning a dfm
   object with combined features from input dfm objects.  Features are matched
@@ -34,9 +36,13 @@ rows, returning a dfm with the combined documents or features, respectively.
 }
 \examples{
 # cbind() for dfm objects
-(dfm1 <- dfm("This is one sample text sample"))
-(dfm2 <- dfm("More words here"))
+(dfm1 <- dfm(c("a b c d", "c d e f")))
+(dfm2 <- dfm(c("a b", "x y z")))
 cbind(dfm1, dfm2)
+cbind(dfm1, 100)
+cbind(100, dfm1)
+cbind(dfm1, matrix(c(101, 102), ncol = 1))
+cbind(matrix(c(101, 102), ncol = 1), dfm1)
 
 # rbind() for dfm objects
 (dfm1 <- dfm(c(doc1 = "This is one sample text sample."), verbose = FALSE))

--- a/man/quanteda_options.Rd
+++ b/man/quanteda_options.Rd
@@ -7,16 +7,16 @@
 quanteda_options(..., reset = FALSE, initialize = FALSE)
 }
 \arguments{
-\item{...}{options to be set, as key-value pair, same as \code{\link{options}}. 
-This may be a list of valid key-value pairs, useful for setting a group of
-options at once (see examples).}
+\item{...}{options to be set, as key-value pair, same as
+\code{\link{options}}. This may be a list of valid key-value pairs, useful
+for setting a group of options at once (see examples).}
 
-\item{reset}{logical; if \code{TRUE}, reset all \pkg{quanteda} options to their 
-default values}
+\item{reset}{logical; if \code{TRUE}, reset all \pkg{quanteda} options to
+their default values}
 
-\item{initialize}{logical; if \code{TRUE}, reset only the \pkg{quanteda} options 
-that are not already defined.  Used for setting initial values when some have 
-been defined previously, such as in `.Rprofile`.}
+\item{initialize}{logical; if \code{TRUE}, reset only the \pkg{quanteda}
+options that are not already defined.  Used for setting initial values when
+some have been defined previously, such as in `.Rprofile`.}
 }
 \value{
 When called using a \code{key = value} pair (where \code{key} can be a label or 
@@ -29,6 +29,22 @@ When called using a \code{key = value} pair (where \code{key} can be a label or
 }
 \description{
 Get or set global options affecting functions across \pkg{quanteda}.
+}
+\details{
+Currently available options are:
+\describe{
+\item{\code{verbose}}{logical; if \code{TRUE} then use this as the default
+   for all functions with a \code{verbose} argument}
+\item{\code{threads}}{integer; specifies the number of threads to use in
+   use this as the setting in all functions that uee parallelization}
+\item{\code{print_dfm_max_ndoc}}{integer; specifies the number of documents
+   to display when using the defaults for printing a dfm}
+\item{\code{print_dfm_max_nfeature}}{integer; specifies the number of features
+   to display when using the defaults for printing a dfm}
+\item{\code{base_docname}}{character; stem name for documents that are
+unnamed when a corpus, tokens, or dfm are created or when a dfm is converted
+from another object}
+}
 }
 \examples{
 (qopts <- quanteda_options())

--- a/man/quanteda_options.Rd
+++ b/man/quanteda_options.Rd
@@ -41,6 +41,10 @@ Currently available options are:
    to display when using the defaults for printing a dfm}
 \item{\code{print_dfm_max_nfeature}}{integer; specifies the number of features
    to display when using the defaults for printing a dfm}
+\item{\code{docname_stem}}{character; stem name for documents that are unnamed
+   when a corpus, tokens, or dfm are created}
+\item{\code{featname_stem}}{character; stem name for features that are unnamed
+   when dfm is converted from another object}
 }
 }
 \examples{

--- a/man/quanteda_options.Rd
+++ b/man/quanteda_options.Rd
@@ -30,23 +30,6 @@ When called using a \code{key = value} pair (where \code{key} can be a label or
 \description{
 Get or set global options affecting functions across \pkg{quanteda}.
 }
-\details{
-Currently available options are:
-\describe{
-\item{\code{verbose}}{logical; if \code{TRUE} then use this as the default
-   for all functions with a \code{verbose} argument}
-\item{\code{threads}}{integer; specifies the number of threads to use in
-   use this as the setting in all functions that uee parallelization}
-\item{\code{print_dfm_max_ndoc}}{integer; specifies the number of documents
-   to display when using the defaults for printing a dfm}
-\item{\code{print_dfm_max_nfeature}}{integer; specifies the number of features
-   to display when using the defaults for printing a dfm}
-\item{\code{docname_stem}}{character; stem name for documents that are unnamed
-   when a corpus, tokens, or dfm are created}
-\item{\code{featname_stem}}{character; stem name for features that are unnamed
-   when dfm is converted from another object}
-}
-}
 \examples{
 (qopts <- quanteda_options())
 \donttest{

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -139,22 +139,6 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// qatd_cpp_sequences
-DataFrame qatd_cpp_sequences(const List& texts_, const CharacterVector& types_, const unsigned int count_min, const IntegerVector sizes_, const String& method, const double smoothing);
-RcppExport SEXP _quanteda_qatd_cpp_sequences(SEXP texts_SEXP, SEXP types_SEXP, SEXP count_minSEXP, SEXP sizes_SEXP, SEXP methodSEXP, SEXP smoothingSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const List& >::type texts_(texts_SEXP);
-    Rcpp::traits::input_parameter< const CharacterVector& >::type types_(types_SEXP);
-    Rcpp::traits::input_parameter< const unsigned int >::type count_min(count_minSEXP);
-    Rcpp::traits::input_parameter< const IntegerVector >::type sizes_(sizes_SEXP);
-    Rcpp::traits::input_parameter< const String& >::type method(methodSEXP);
-    Rcpp::traits::input_parameter< const double >::type smoothing(smoothingSEXP);
-    rcpp_result_gen = Rcpp::wrap(qatd_cpp_sequences(texts_, types_, count_min, sizes_, method, smoothing));
-    return rcpp_result_gen;
-END_RCPP
-}
 // qatd_cpp_sequences_old
 DataFrame qatd_cpp_sequences_old(const List& texts_, const IntegerVector& words_, const CharacterVector& types_, const unsigned int count_min, unsigned int len_max, bool nested, bool ordered);
 RcppExport SEXP _quanteda_qatd_cpp_sequences_old(SEXP texts_SEXP, SEXP words_SEXP, SEXP types_SEXP, SEXP count_minSEXP, SEXP len_maxSEXP, SEXP nestedSEXP, SEXP orderedSEXP) {
@@ -169,6 +153,22 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< bool >::type nested(nestedSEXP);
     Rcpp::traits::input_parameter< bool >::type ordered(orderedSEXP);
     rcpp_result_gen = Rcpp::wrap(qatd_cpp_sequences_old(texts_, words_, types_, count_min, len_max, nested, ordered));
+    return rcpp_result_gen;
+END_RCPP
+}
+// qatd_cpp_sequences
+DataFrame qatd_cpp_sequences(const List& texts_, const CharacterVector& types_, const unsigned int count_min, const IntegerVector sizes_, const String& method, const double smoothing);
+RcppExport SEXP _quanteda_qatd_cpp_sequences(SEXP texts_SEXP, SEXP types_SEXP, SEXP count_minSEXP, SEXP sizes_SEXP, SEXP methodSEXP, SEXP smoothingSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const List& >::type texts_(texts_SEXP);
+    Rcpp::traits::input_parameter< const CharacterVector& >::type types_(types_SEXP);
+    Rcpp::traits::input_parameter< const unsigned int >::type count_min(count_minSEXP);
+    Rcpp::traits::input_parameter< const IntegerVector >::type sizes_(sizes_SEXP);
+    Rcpp::traits::input_parameter< const String& >::type method(methodSEXP);
+    Rcpp::traits::input_parameter< const double >::type smoothing(smoothingSEXP);
+    rcpp_result_gen = Rcpp::wrap(qatd_cpp_sequences(texts_, types_, count_min, sizes_, method, smoothing));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -322,25 +322,6 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// wordfishcpp
-Rcpp::List wordfishcpp(arma::sp_mat& wfm, IntegerVector& dirvec, NumericVector& priorvec, NumericVector& tolvec, IntegerVector& disptype, NumericVector& dispmin, bool ABS, bool svd_on, double residual_floor);
-RcppExport SEXP _quanteda_wordfishcpp(SEXP wfmSEXP, SEXP dirvecSEXP, SEXP priorvecSEXP, SEXP tolvecSEXP, SEXP disptypeSEXP, SEXP dispminSEXP, SEXP ABSSEXP, SEXP svd_onSEXP, SEXP residual_floorSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< arma::sp_mat& >::type wfm(wfmSEXP);
-    Rcpp::traits::input_parameter< IntegerVector& >::type dirvec(dirvecSEXP);
-    Rcpp::traits::input_parameter< NumericVector& >::type priorvec(priorvecSEXP);
-    Rcpp::traits::input_parameter< NumericVector& >::type tolvec(tolvecSEXP);
-    Rcpp::traits::input_parameter< IntegerVector& >::type disptype(disptypeSEXP);
-    Rcpp::traits::input_parameter< NumericVector& >::type dispmin(dispminSEXP);
-    Rcpp::traits::input_parameter< bool >::type ABS(ABSSEXP);
-    Rcpp::traits::input_parameter< bool >::type svd_on(svd_onSEXP);
-    Rcpp::traits::input_parameter< double >::type residual_floor(residual_floorSEXP);
-    rcpp_result_gen = Rcpp::wrap(wordfishcpp(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor));
-    return rcpp_result_gen;
-END_RCPP
-}
 // wordfishcpp_dense
 Rcpp::List wordfishcpp_dense(SEXP wfm, SEXP dir, SEXP priors, SEXP tol, SEXP disp, SEXP dispfloor, bool abs_err);
 RcppExport SEXP _quanteda_wordfishcpp_dense(SEXP wfmSEXP, SEXP dirSEXP, SEXP priorsSEXP, SEXP tolSEXP, SEXP dispSEXP, SEXP dispfloorSEXP, SEXP abs_errSEXP) {
@@ -377,6 +358,25 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// wordfishcpp
+Rcpp::List wordfishcpp(arma::sp_mat& wfm, IntegerVector& dirvec, NumericVector& priorvec, NumericVector& tolvec, IntegerVector& disptype, NumericVector& dispmin, bool ABS, bool svd_on, double residual_floor);
+RcppExport SEXP _quanteda_wordfishcpp(SEXP wfmSEXP, SEXP dirvecSEXP, SEXP priorvecSEXP, SEXP tolvecSEXP, SEXP disptypeSEXP, SEXP dispminSEXP, SEXP ABSSEXP, SEXP svd_onSEXP, SEXP residual_floorSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< arma::sp_mat& >::type wfm(wfmSEXP);
+    Rcpp::traits::input_parameter< IntegerVector& >::type dirvec(dirvecSEXP);
+    Rcpp::traits::input_parameter< NumericVector& >::type priorvec(priorvecSEXP);
+    Rcpp::traits::input_parameter< NumericVector& >::type tolvec(tolvecSEXP);
+    Rcpp::traits::input_parameter< IntegerVector& >::type disptype(disptypeSEXP);
+    Rcpp::traits::input_parameter< NumericVector& >::type dispmin(dispminSEXP);
+    Rcpp::traits::input_parameter< bool >::type ABS(ABSSEXP);
+    Rcpp::traits::input_parameter< bool >::type svd_on(svd_onSEXP);
+    Rcpp::traits::input_parameter< double >::type residual_floor(residual_floorSEXP);
+    rcpp_result_gen = Rcpp::wrap(wordfishcpp(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor));
+    return rcpp_result_gen;
+END_RCPP
+}
 
 static const R_CallMethodDef CallEntries[] = {
     {"_quanteda_cacpp", (DL_FUNC) &_quanteda_cacpp, 3},
@@ -389,8 +389,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_quanteda_qatd_MinkowskiPara_cpp", (DL_FUNC) &_quanteda_qatd_MinkowskiPara_cpp, 3},
     {"_quanteda_qatd_MinkowskiPara_cpp2", (DL_FUNC) &_quanteda_qatd_MinkowskiPara_cpp2, 4},
     {"_quanteda_qatd_cpp_fcm", (DL_FUNC) &_quanteda_qatd_cpp_fcm, 8},
-    {"_quanteda_qatd_cpp_sequences", (DL_FUNC) &_quanteda_qatd_cpp_sequences, 6},
     {"_quanteda_qatd_cpp_sequences_old", (DL_FUNC) &_quanteda_qatd_cpp_sequences_old, 7},
+    {"_quanteda_qatd_cpp_sequences", (DL_FUNC) &_quanteda_qatd_cpp_sequences, 6},
     {"_quanteda_qatd_cpp_tokens_compound", (DL_FUNC) &_quanteda_qatd_cpp_tokens_compound, 5},
     {"_quanteda_qatd_cpp_tokens_detect", (DL_FUNC) &_quanteda_qatd_cpp_tokens_detect, 2},
     {"_quanteda_qatd_cpp_kwic", (DL_FUNC) &_quanteda_qatd_cpp_kwic, 5},
@@ -402,9 +402,9 @@ static const R_CallMethodDef CallEntries[] = {
     {"_quanteda_qatd_cpp_tokens_select", (DL_FUNC) &_quanteda_qatd_cpp_tokens_select, 5},
     {"_quanteda_qatd_cpp_chars_remove", (DL_FUNC) &_quanteda_qatd_cpp_chars_remove, 2},
     {"_quanteda_qatd_cpp_tbb_enabled", (DL_FUNC) &_quanteda_qatd_cpp_tbb_enabled, 0},
-    {"_quanteda_wordfishcpp", (DL_FUNC) &_quanteda_wordfishcpp, 9},
     {"_quanteda_wordfishcpp_dense", (DL_FUNC) &_quanteda_wordfishcpp_dense, 7},
     {"_quanteda_wordfishcpp_mt", (DL_FUNC) &_quanteda_wordfishcpp_mt, 9},
+    {"_quanteda_wordfishcpp", (DL_FUNC) &_quanteda_wordfishcpp, 9},
     {NULL, NULL, 0}
 };
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -139,6 +139,22 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// qatd_cpp_sequences
+DataFrame qatd_cpp_sequences(const List& texts_, const CharacterVector& types_, const unsigned int count_min, const IntegerVector sizes_, const String& method, const double smoothing);
+RcppExport SEXP _quanteda_qatd_cpp_sequences(SEXP texts_SEXP, SEXP types_SEXP, SEXP count_minSEXP, SEXP sizes_SEXP, SEXP methodSEXP, SEXP smoothingSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const List& >::type texts_(texts_SEXP);
+    Rcpp::traits::input_parameter< const CharacterVector& >::type types_(types_SEXP);
+    Rcpp::traits::input_parameter< const unsigned int >::type count_min(count_minSEXP);
+    Rcpp::traits::input_parameter< const IntegerVector >::type sizes_(sizes_SEXP);
+    Rcpp::traits::input_parameter< const String& >::type method(methodSEXP);
+    Rcpp::traits::input_parameter< const double >::type smoothing(smoothingSEXP);
+    rcpp_result_gen = Rcpp::wrap(qatd_cpp_sequences(texts_, types_, count_min, sizes_, method, smoothing));
+    return rcpp_result_gen;
+END_RCPP
+}
 // qatd_cpp_sequences_old
 DataFrame qatd_cpp_sequences_old(const List& texts_, const IntegerVector& words_, const CharacterVector& types_, const unsigned int count_min, unsigned int len_max, bool nested, bool ordered);
 RcppExport SEXP _quanteda_qatd_cpp_sequences_old(SEXP texts_SEXP, SEXP words_SEXP, SEXP types_SEXP, SEXP count_minSEXP, SEXP len_maxSEXP, SEXP nestedSEXP, SEXP orderedSEXP) {
@@ -153,22 +169,6 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< bool >::type nested(nestedSEXP);
     Rcpp::traits::input_parameter< bool >::type ordered(orderedSEXP);
     rcpp_result_gen = Rcpp::wrap(qatd_cpp_sequences_old(texts_, words_, types_, count_min, len_max, nested, ordered));
-    return rcpp_result_gen;
-END_RCPP
-}
-// qatd_cpp_sequences
-DataFrame qatd_cpp_sequences(const List& texts_, const CharacterVector& types_, const unsigned int count_min, const IntegerVector sizes_, const String& method, const double smoothing);
-RcppExport SEXP _quanteda_qatd_cpp_sequences(SEXP texts_SEXP, SEXP types_SEXP, SEXP count_minSEXP, SEXP sizes_SEXP, SEXP methodSEXP, SEXP smoothingSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const List& >::type texts_(texts_SEXP);
-    Rcpp::traits::input_parameter< const CharacterVector& >::type types_(types_SEXP);
-    Rcpp::traits::input_parameter< const unsigned int >::type count_min(count_minSEXP);
-    Rcpp::traits::input_parameter< const IntegerVector >::type sizes_(sizes_SEXP);
-    Rcpp::traits::input_parameter< const String& >::type method(methodSEXP);
-    Rcpp::traits::input_parameter< const double >::type smoothing(smoothingSEXP);
-    rcpp_result_gen = Rcpp::wrap(qatd_cpp_sequences(texts_, types_, count_min, sizes_, method, smoothing));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -322,6 +322,25 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// wordfishcpp
+Rcpp::List wordfishcpp(arma::sp_mat& wfm, IntegerVector& dirvec, NumericVector& priorvec, NumericVector& tolvec, IntegerVector& disptype, NumericVector& dispmin, bool ABS, bool svd_on, double residual_floor);
+RcppExport SEXP _quanteda_wordfishcpp(SEXP wfmSEXP, SEXP dirvecSEXP, SEXP priorvecSEXP, SEXP tolvecSEXP, SEXP disptypeSEXP, SEXP dispminSEXP, SEXP ABSSEXP, SEXP svd_onSEXP, SEXP residual_floorSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< arma::sp_mat& >::type wfm(wfmSEXP);
+    Rcpp::traits::input_parameter< IntegerVector& >::type dirvec(dirvecSEXP);
+    Rcpp::traits::input_parameter< NumericVector& >::type priorvec(priorvecSEXP);
+    Rcpp::traits::input_parameter< NumericVector& >::type tolvec(tolvecSEXP);
+    Rcpp::traits::input_parameter< IntegerVector& >::type disptype(disptypeSEXP);
+    Rcpp::traits::input_parameter< NumericVector& >::type dispmin(dispminSEXP);
+    Rcpp::traits::input_parameter< bool >::type ABS(ABSSEXP);
+    Rcpp::traits::input_parameter< bool >::type svd_on(svd_onSEXP);
+    Rcpp::traits::input_parameter< double >::type residual_floor(residual_floorSEXP);
+    rcpp_result_gen = Rcpp::wrap(wordfishcpp(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor));
+    return rcpp_result_gen;
+END_RCPP
+}
 // wordfishcpp_dense
 Rcpp::List wordfishcpp_dense(SEXP wfm, SEXP dir, SEXP priors, SEXP tol, SEXP disp, SEXP dispfloor, bool abs_err);
 RcppExport SEXP _quanteda_wordfishcpp_dense(SEXP wfmSEXP, SEXP dirSEXP, SEXP priorsSEXP, SEXP tolSEXP, SEXP dispSEXP, SEXP dispfloorSEXP, SEXP abs_errSEXP) {
@@ -358,25 +377,6 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// wordfishcpp
-Rcpp::List wordfishcpp(arma::sp_mat& wfm, IntegerVector& dirvec, NumericVector& priorvec, NumericVector& tolvec, IntegerVector& disptype, NumericVector& dispmin, bool ABS, bool svd_on, double residual_floor);
-RcppExport SEXP _quanteda_wordfishcpp(SEXP wfmSEXP, SEXP dirvecSEXP, SEXP priorvecSEXP, SEXP tolvecSEXP, SEXP disptypeSEXP, SEXP dispminSEXP, SEXP ABSSEXP, SEXP svd_onSEXP, SEXP residual_floorSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< arma::sp_mat& >::type wfm(wfmSEXP);
-    Rcpp::traits::input_parameter< IntegerVector& >::type dirvec(dirvecSEXP);
-    Rcpp::traits::input_parameter< NumericVector& >::type priorvec(priorvecSEXP);
-    Rcpp::traits::input_parameter< NumericVector& >::type tolvec(tolvecSEXP);
-    Rcpp::traits::input_parameter< IntegerVector& >::type disptype(disptypeSEXP);
-    Rcpp::traits::input_parameter< NumericVector& >::type dispmin(dispminSEXP);
-    Rcpp::traits::input_parameter< bool >::type ABS(ABSSEXP);
-    Rcpp::traits::input_parameter< bool >::type svd_on(svd_onSEXP);
-    Rcpp::traits::input_parameter< double >::type residual_floor(residual_floorSEXP);
-    rcpp_result_gen = Rcpp::wrap(wordfishcpp(wfm, dirvec, priorvec, tolvec, disptype, dispmin, ABS, svd_on, residual_floor));
-    return rcpp_result_gen;
-END_RCPP
-}
 
 static const R_CallMethodDef CallEntries[] = {
     {"_quanteda_cacpp", (DL_FUNC) &_quanteda_cacpp, 3},
@@ -389,8 +389,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_quanteda_qatd_MinkowskiPara_cpp", (DL_FUNC) &_quanteda_qatd_MinkowskiPara_cpp, 3},
     {"_quanteda_qatd_MinkowskiPara_cpp2", (DL_FUNC) &_quanteda_qatd_MinkowskiPara_cpp2, 4},
     {"_quanteda_qatd_cpp_fcm", (DL_FUNC) &_quanteda_qatd_cpp_fcm, 8},
-    {"_quanteda_qatd_cpp_sequences_old", (DL_FUNC) &_quanteda_qatd_cpp_sequences_old, 7},
     {"_quanteda_qatd_cpp_sequences", (DL_FUNC) &_quanteda_qatd_cpp_sequences, 6},
+    {"_quanteda_qatd_cpp_sequences_old", (DL_FUNC) &_quanteda_qatd_cpp_sequences_old, 7},
     {"_quanteda_qatd_cpp_tokens_compound", (DL_FUNC) &_quanteda_qatd_cpp_tokens_compound, 5},
     {"_quanteda_qatd_cpp_tokens_detect", (DL_FUNC) &_quanteda_qatd_cpp_tokens_detect, 2},
     {"_quanteda_qatd_cpp_kwic", (DL_FUNC) &_quanteda_qatd_cpp_kwic, 5},
@@ -402,9 +402,9 @@ static const R_CallMethodDef CallEntries[] = {
     {"_quanteda_qatd_cpp_tokens_select", (DL_FUNC) &_quanteda_qatd_cpp_tokens_select, 5},
     {"_quanteda_qatd_cpp_chars_remove", (DL_FUNC) &_quanteda_qatd_cpp_chars_remove, 2},
     {"_quanteda_qatd_cpp_tbb_enabled", (DL_FUNC) &_quanteda_qatd_cpp_tbb_enabled, 0},
+    {"_quanteda_wordfishcpp", (DL_FUNC) &_quanteda_wordfishcpp, 9},
     {"_quanteda_wordfishcpp_dense", (DL_FUNC) &_quanteda_wordfishcpp_dense, 7},
     {"_quanteda_wordfishcpp_mt", (DL_FUNC) &_quanteda_wordfishcpp_mt, 9},
-    {"_quanteda_wordfishcpp", (DL_FUNC) &_quanteda_wordfishcpp, 9},
     {NULL, NULL, 0}
 };
 

--- a/tests/testthat/test-as.dfm.R
+++ b/tests/testthat/test-as.dfm.R
@@ -7,7 +7,7 @@ test_that("as.dfm adds document and feature names when a matrix has none", {
     m <- matrix(elements, nrow = 4)
     expect_equal(
         docnames(as.dfm(m)),
-        paste0("doc", seq_len(nrow(m)))
+        paste0("text", seq_len(nrow(m)))
     )
     expect_equal(
         featnames(as.dfm(m)),
@@ -21,11 +21,11 @@ test_that("as.dfm adds document and feature names when a matrix has none", {
 
 test_that("as.dfm adds names of dimnames when a matrix has none", {
     m <- matrix(elements, nrow = 4)
-    dimnames(m) <- list(paste0("doc", seq_len(nrow(m))),
+    dimnames(m) <- list(paste0("text", seq_len(nrow(m))),
                         letters[seq_len(ncol(m))])
     expect_equal(
         docnames(as.dfm(m)),
-        paste0("doc", seq_len(nrow(m)))
+        paste0("text", seq_len(nrow(m)))
     )
     expect_equal(
         featnames(as.dfm(m)),
@@ -55,11 +55,11 @@ test_that("as.dfm keeps document and feature names from a data.frame", {
 
 test_that("as.dfm adds names of dimnames when a data.frame has none", {
     m <- data.frame(matrix(elements, nrow = 4))
-    dimnames(m) <- list(paste0("doc", seq_len(nrow(m))),
+    dimnames(m) <- list(paste0("text", seq_len(nrow(m))),
                         letters[seq_len(ncol(m))])
     expect_equal(
         docnames(as.dfm(m)),
-        paste0("doc", seq_len(nrow(m)))
+        paste0("text", seq_len(nrow(m)))
     )
     expect_equal(
         featnames(as.dfm(m)),

--- a/tests/testthat/test-convert.R
+++ b/tests/testthat/test-convert.R
@@ -105,14 +105,14 @@ test_that("test stm converter: under extreme situations ", {
                              0, 0, 1, 2, 
                              0, 0, 0, 0, 
                              1, 2, 3, 4), byrow = TRUE, nrow = 4))
-    expect_warning(convert(mydfm, to = "stm"), "Dropped empty document\\(s\\): doc3")
+    expect_warning(convert(mydfm, to = "stm"), "Dropped empty document\\(s\\): text3")
 
     #zero-count feature
     mydfm <- as.dfm(matrix(c(1, 0, 2, 0, 
                              0, 0, 1, 2, 
                              1, 0, 0, 0, 
                              1, 0, 3, 4), byrow = TRUE, nrow = 4))
-    expect_warning(stmdfm<-convert(mydfm, to = "stm"), "zero-count features: feat2")
+    expect_warning(stmdfm <- convert(mydfm, to = "stm"), "zero-count features: feat2")
     
     skip_if_not_installed("stm")
     require(stm)

--- a/tests/testthat/test-dfm.R
+++ b/tests/testthat/test-dfm.R
@@ -317,6 +317,17 @@ test_that("cbind.dfm works with non-dfm objects",{
                dimnames = list(docs = c("text1", "text2"), features = c(letters[1:5], "feat", "f1", "f2")))
     )
 
+    expect_equal(
+        as.matrix(cbind(vec, dfm1, vec)),
+        matrix(c(10,1,1,1,0,0,10, 20,0,0,1,1,1,20), byrow = TRUE, nrow = 2,
+               dimnames = list(docs = c("text1", "text2"), features = c("feat", letters[1:5], "feat1")))
+    )
+
+    expect_silent(cbind(vec, dfm1, vec))
+    expect_warning(
+        cbind(dfm1, dfm1),
+        "cbinding dfms with overlapping features will result in duplicated features"
+    )
 })
 
 

--- a/tests/testthat/test-dfm.R
+++ b/tests/testthat/test-dfm.R
@@ -284,6 +284,42 @@ test_that("cbind.dfm works as expected",{
                  c("docs", "features"))
 })
 
+test_that("cbind.dfm works with non-dfm objects",{
+    dfm1 <- dfm(c("a b c", "c d e"))
+    
+    vec <- c(10, 20)
+    expect_equal(
+        as.matrix(cbind(dfm1, vec)),
+        matrix(c(1,1,1,0,0,10, 0,0,1,1,1,20), byrow = TRUE, nrow = 2,
+               dimnames = list(docs = c("text1", "text2"), features = c(letters[1:5], "feat")))
+    )
+    expect_equal(
+        as.matrix(cbind(vec, dfm1)),
+        matrix(c(10,1,1,1,0,0, 20, 0,0,1,1,1), byrow = TRUE, nrow = 2,
+               dimnames = list(docs = c("text1", "text2"), features = c("feat", letters[1:5])))
+    )
+    
+    mat <- matrix(1:4, nrow = 2, dimnames = list(NULL, c("f1", "f2")))
+    expect_equal(
+        as.matrix(cbind(dfm1, mat)),
+        matrix(c(1,1,1,0,0,1,3, 0,0,1,1,1,2,4), byrow = TRUE, nrow = 2,
+               dimnames = list(docs = c("text1", "text2"), features = c(letters[1:5], "f1", "f2")))
+    )
+    expect_equal(
+        as.matrix(cbind(mat, dfm1)),
+        matrix(c(1,3,1,1,1,0,0, 2,4,0,0,1,1,1), byrow = TRUE, nrow = 2,
+               dimnames = list(docs = c("text1", "text2"), features = c("f1", "f2", letters[1:5])))
+    )
+    
+    expect_equal(
+        as.matrix(cbind(dfm1, vec, mat)),
+        matrix(c(1,1,1,0,0,10,1,3, 0,0,1,1,1,20,2,4), byrow = TRUE, nrow = 2,
+               dimnames = list(docs = c("text1", "text2"), features = c(letters[1:5], "feat", "f1", "f2")))
+    )
+
+})
+
+
 test_that("rbind.dfm works as expected",{
     dfm1 <- dfm("This is one sample text sample")
     dfm2 <- dfm("More words here")

--- a/tests/testthat/test-dfm.R
+++ b/tests/testthat/test-dfm.R
@@ -328,6 +328,13 @@ test_that("cbind.dfm works with non-dfm objects",{
         cbind(dfm1, dfm1),
         "cbinding dfms with overlapping features will result in duplicated features"
     )
+    
+    expect_equal(
+        as.matrix(cbind(dfm1, 100)),
+        matrix(c(1,1,1,0,0,100, 0,0,1,1,1,100), byrow = TRUE, nrow = 2,
+               dimnames = list(docs = c("text1", "text2"), features = c(letters[1:5], "feat")))
+    )
+    
 })
 
 test_that("more cbind tests for dfms", {

--- a/tests/testthat/test-dfm.R
+++ b/tests/testthat/test-dfm.R
@@ -330,6 +330,33 @@ test_that("cbind.dfm works with non-dfm objects",{
     )
 })
 
+test_that("more cbind tests for dfms", {
+    txts <- c("a b c d", "b c d e") 
+    mydfm <- dfm(txts)
+    
+    expect_equal(
+        as.matrix(cbind(mydfm, as.dfm(cbind("ALL" = ntoken(mydfm))))),
+        matrix(c(1,1,1,1,0,4, 0,1,1,1,1,4), byrow = TRUE, nrow = 2,
+                  dimnames = list(docs = c("text1", "text2"), features = c(letters[1:5], "ALL")))
+    )
+    
+    expect_equal(
+        as.matrix(cbind(mydfm, cbind("ALL" = ntoken(mydfm)))),
+        matrix(c(1,1,1,1,0,4, 0,1,1,1,1,4), byrow = TRUE, nrow = 2,
+               dimnames = list(docs = c("text1", "text2"), features = c(letters[1:5], "ALL")))
+    )
+
+    expect_equal(
+        as.matrix(cbind(mydfm, "ALL" = ntoken(mydfm))),
+        matrix(c(1,1,1,1,0,4, 0,1,1,1,1,4), byrow = TRUE, nrow = 2,
+               dimnames = list(docs = c("text1", "text2"), features = c(letters[1:5], "ALL")))
+    )
+    expect_equal(
+        as.matrix(cbind(mydfm, ntoken(mydfm))),
+        matrix(c(1,1,1,1,0,4, 0,1,1,1,1,4), byrow = TRUE, nrow = 2,
+               dimnames = list(docs = c("text1", "text2"), features = c(letters[1:5], "feat")))
+    )
+})
 
 test_that("rbind.dfm works as expected",{
     dfm1 <- dfm("This is one sample text sample")

--- a/tests/testthat/test-dfm_group.R
+++ b/tests/testthat/test-dfm_group.R
@@ -74,17 +74,17 @@ test_that("test dfm_group with factor levels, fill = TRUE and FALSE, #854", {
     )
     
     testdfm <- dfm(c('a b c c', 'b c d', 'a'))
-    external_factor <- factor(c('doc1', 'doc1', 'doc2'), 
-                              levels = c('doc0', 'doc1', 'doc2', 'doc3'))
+    external_factor <- factor(c("text1", "text1", "text2"), 
+                              levels = paste0("text", 0:3))
     expect_equal(
         as.matrix(dfm_group(testdfm, groups = external_factor, fill = FALSE)),
         matrix(c(1,2,3,1, 1,0,0,0), byrow = TRUE, nrow = 2, 
-               dimnames = list(docs = c('doc1', 'doc2'), features = letters[1:4]))
+               dimnames = list(docs = c('text1', 'text2'), features = letters[1:4]))
     )
     expect_equal(
         as.matrix(dfm_group(testdfm, groups = external_factor, fill = TRUE)),
         matrix(c(0,0,0,0, 1,2,3,1, 1,0,0,0, 0,0,0,0), byrow = TRUE, nrow = 4, 
-               dimnames = list(docs = paste0("doc", 0:3), features = letters[1:4]))
+               dimnames = list(docs = paste0("text", 0:3), features = letters[1:4]))
     )
     # new documents in factor order
     expect_equal(


### PR DESCRIPTION
Adds methods for:
- cbind: dfm + numeric, numeric + dfm, dfm + matrix, matrix + dfm

Adds `quanteda_options`: `docnames_stem` and `featnames_stem` to centralise the sub names for documents and features that are unassigned. (I noticed that what is done in `corpus()` and `dfm()` was different from `as.dfm()`.)

Still needed: 
- [x] make the new methods applicable to all cbind objects passed in the `...`
- [x] add tests
