### PR TITLE
Don't issue an error for wordstem if a character element is *entirely* whitespace

### DIFF
--- a/R/wordstem.R
+++ b/R/wordstem.R
@@ -79,7 +79,7 @@ char_wordstem <- function(x, language = quanteda_options("language_stemmer")) {
 #' @noRd
 #' @export
 char_wordstem.character <- function(x, language = quanteda_options("language_stemmer")) {
-    if (any(stringi::stri_detect_fixed(x, " ") & !is.na(x)))
+    if (any(stringi::stri_detect_regex(x, "^\\P{Z}+\\p{Z}+") & !is.na(x)))
         stop("whitespace detected: you can only stem tokenized texts")
     result <- SnowballC::wordStem(x, language)
     result[which(is.na(x))] <- NA

--- a/tests/testthat/test-dfm.R
+++ b/tests/testthat/test-dfm.R
@@ -566,4 +566,5 @@ test_that("dfm works with stem options", {
         featnames(dfm(txt_french, stem = TRUE)),
         "cour"
     )
+    quanteda_options(reset = TRUE)
 })

--- a/tests/testthat/test-wordstem.R
+++ b/tests/testthat/test-wordstem.R
@@ -16,7 +16,7 @@ test_that("can wordstem dfms with zero features and zero docs", {
     mydfm <- dfm(c("stemming porter three", "stemming four five"))
     mydfm[2, 4] <- 0
     mydfm <- new("dfmSparse", mydfm)
-    dfm_wordstem(mydfm)
+    dfm_wordstem(mydfm, language = "english")
     expect_equal(nfeature(dfm_wordstem(mydfm)), 5)
     
 })
@@ -72,7 +72,7 @@ test_that("wordstem works on tokens that include separators (#909)", {
     txt <- "Tests for developers."
     toks <- tokens(txt, remove_separators = FALSE, remove_punct = TRUE)
     expect_equal(
-        as.list(tokens_wordstem(toks)),
-        list(text1 = c("Test", " ", "for", " ", "developer"))
+        as.list(tokens_wordstem(toks, language = "english")),
+        list(text1 = c("Test", " ", "for", " ", "develop"))
     )
 })

--- a/tests/testthat/test-wordstem.R
+++ b/tests/testthat/test-wordstem.R
@@ -68,3 +68,11 @@ test_that("wordstem works with tokens with padding = TRUE", {
                       d2 = c("", "two", "")))
 })
 
+test_that("wordstem works on tokens that include separators (#909)", {
+    txt <- "Tests for developers."
+    toks <- tokens(txt, remove_separators = FALSE, remove_punct = TRUE)
+    expect_equal(
+        as.list(tokens_wordstem(toks)),
+        list(text1 = c("Test", " ", "for", " ", "developer"))
+    )
+})


### PR DESCRIPTION
Fixes #909

```r
txt <- "Tests for developers."
toks <- tokens(txt, remove_separators = FALSE, remove_punct = TRUE)
tokens_wordstem(toks)
# tokens from 1 document.
# text1 :
# [1] "Test"      " "         "for"       " "         "developer"
```