### PR TITLE
Typo correction in textstat_dist() argument

### DIFF
--- a/vignettes/quickstart.Rmd
+++ b/vignettes/quickstart.Rmd
@@ -510,7 +510,7 @@ presDfm <- dfm(corpus_subset(data_corpus_SOTU, Date > as.Date("1980-01-01")),
                remove = stopwords("english"))
 presDfm <- dfm_trim(presDfm, min_count = 5, min_docfreq = 3)
 # hierarchical clustering - get distances on normalized dfm
-presDistMat <- textstat_dist(dfm_weight(presDfm, "relfreq"))
+presDistMat <- textstat_dist(dfm_weight(presDfm, "relFreq"))
 # hiarchical clustering the distance object
 presCluster <- hclust(presDistMat)
 # label with document names


### PR DESCRIPTION
I got an error 
`"Error in match.arg(type) : 'arg' should be one of “frequency”, “relFreq”, “relMaxFreq”, “logFreq”, “tfidf”`
while going through vignette. So I think `relfreq` should be `relFreq`