### PR TITLE
Make corpus_trim() internal only

### DIFF
--- a/R/corpus_trim.R
+++ b/R/corpus_trim.R
@@ -14,7 +14,7 @@
 #'   For documents whose sentences have been removed entirely, a null string
 #'   (\code{""}) will be returned.
 #' @export
-#' @keywords corpus
+#' @keywords corpus internal
 #' @examples
 #' txt <- c("PAGE 1. This is a single sentence.  Short sentence. Three word sentence.",
 #'          "PAGE 2. Very short! Shorter.",

--- a/man/corpus_trim.Rd
+++ b/man/corpus_trim.Rd
@@ -51,3 +51,4 @@ char_trim(txt, "sentences", exclude_pattern = "sentence\\\\.")
 }
 \keyword{character}
 \keyword{corpus}
+\keyword{internal}


### PR DESCRIPTION
Keeps `corpus_trim()` and the already internal `corpus_trimsentences()` but makes the former internal as well.