### PR TITLE
Issue 956

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -41,8 +41,8 @@ qatd_cpp_fcm <- function(texts_, n_types, count, window, weights, ordered, tri, 
     .Call(`_quanteda_qatd_cpp_fcm`, texts_, n_types, count, window, weights, ordered, tri, nvec)
 }
 
-qatd_cpp_sequences <- function(texts_, types_, count_min, sizes_, method, smoothing) {
-    .Call(`_quanteda_qatd_cpp_sequences`, texts_, types_, count_min, sizes_, method, smoothing)
+qatd_cpp_sequences <- function(texts_, types_, words_ignore_, count_min, sizes_, method, smoothing) {
+    .Call(`_quanteda_qatd_cpp_sequences`, texts_, types_, words_ignore_, count_min, sizes_, method, smoothing)
 }
 
 qatd_cpp_tokens_compound <- function(texts_, comps_, types_, delim_, join) {

--- a/R/regex2fixed.R
+++ b/R/regex2fixed.R
@@ -126,7 +126,7 @@ regex2id <- function(pattern, types = NULL, valuetype = NULL, case_insensitive =
 search_glob <- function(patterns, types_search, index) {
     lapply(patterns, function(pattern, types_search, index) {
         if (pattern == '') {
-            return(NULL) # return nothing for empty pattern
+            return(integer(0)) # return nothing for empty pattern
         } else if (pattern == '*') {
             return(seq_along(types_search)) # return all types when glob is *
         } else {
@@ -140,7 +140,7 @@ search_glob <- function(patterns, types_search, index) {
                                                case_insensitive = FALSE)))
             } else {
                 #cat("Not found\n")
-                return(NULL)
+                return(integer(0))
             }
         }
     }, types_search, index)
@@ -151,7 +151,7 @@ search_glob <- function(patterns, types_search, index) {
 search_regex <- function(patterns, types_search, case_insensitive) {
     lapply(patterns, function(pattern, types_search, case_insensitive) {
         if (pattern == '') {
-            return(NULL)
+            return(integer(0))
         } else {
             return(which(stri_detect_regex(types_search, pattern, 
                                            case_insensitive = case_insensitive)))
@@ -164,7 +164,7 @@ search_regex <- function(patterns, types_search, case_insensitive) {
 search_fixed <- function(patterns, types_search, index) {
     lapply(patterns, function(pattern, types_search, index) {
         if (pattern == '') {
-            return(NULL)
+            return(integer(0))
         } else {
             return(search_index(pattern, index))
         }

--- a/R/utils.R
+++ b/R/utils.R
@@ -274,20 +274,6 @@ escape_regex <- function(x){
     stri_replace_all_regex(x, "([.()^\\{\\}+$\\[\\]\\\\])", "\\\\$1") # allow glob
 }
 
-# which object class started the call stack?
-# @param x sys.calls() from inside a function
-# @param function_name the base name of the method of the function
-# @examples
-# who_called_me_first(sys.calls(), "dfm")
-who_called_me_first <- function(x, function_name) {
-    x <- as.character(x)
-    base_call_index <- which(stringi::stri_startswith_fixed(x, function_name))
-    base_call_index <- which(stringi::stri_detect_regex(x, paste0("^(quanteda::){0,1}", function_name, "(\\.\\w+){0,1}\\(")))
-    x <- x[base_call_index[-1]]
-    x <- stringi::stri_replace_all_regex(x, paste0(function_name, "\\.(\\w+)\\(.+$"), "$1")
-    x[1]
-}
-
 # function to check dots arguments against a list of permissible arguments
 check_dots <-  function(dots, permissible_args = NULL) {
     if (length(dots) == 0) return()

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -140,18 +140,19 @@ BEGIN_RCPP
 END_RCPP
 }
 // qatd_cpp_sequences
-DataFrame qatd_cpp_sequences(const List& texts_, const CharacterVector& types_, const unsigned int count_min, const IntegerVector sizes_, const String& method, const double smoothing);
-RcppExport SEXP _quanteda_qatd_cpp_sequences(SEXP texts_SEXP, SEXP types_SEXP, SEXP count_minSEXP, SEXP sizes_SEXP, SEXP methodSEXP, SEXP smoothingSEXP) {
+DataFrame qatd_cpp_sequences(const List& texts_, const CharacterVector& types_, const IntegerVector& words_ignore_, const unsigned int count_min, const IntegerVector sizes_, const String& method, const double smoothing);
+RcppExport SEXP _quanteda_qatd_cpp_sequences(SEXP texts_SEXP, SEXP types_SEXP, SEXP words_ignore_SEXP, SEXP count_minSEXP, SEXP sizes_SEXP, SEXP methodSEXP, SEXP smoothingSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const List& >::type texts_(texts_SEXP);
     Rcpp::traits::input_parameter< const CharacterVector& >::type types_(types_SEXP);
+    Rcpp::traits::input_parameter< const IntegerVector& >::type words_ignore_(words_ignore_SEXP);
     Rcpp::traits::input_parameter< const unsigned int >::type count_min(count_minSEXP);
     Rcpp::traits::input_parameter< const IntegerVector >::type sizes_(sizes_SEXP);
     Rcpp::traits::input_parameter< const String& >::type method(methodSEXP);
     Rcpp::traits::input_parameter< const double >::type smoothing(smoothingSEXP);
-    rcpp_result_gen = Rcpp::wrap(qatd_cpp_sequences(texts_, types_, count_min, sizes_, method, smoothing));
+    rcpp_result_gen = Rcpp::wrap(qatd_cpp_sequences(texts_, types_, words_ignore_, count_min, sizes_, method, smoothing));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -373,7 +374,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_quanteda_qatd_MinkowskiPara_cpp", (DL_FUNC) &_quanteda_qatd_MinkowskiPara_cpp, 3},
     {"_quanteda_qatd_MinkowskiPara_cpp2", (DL_FUNC) &_quanteda_qatd_MinkowskiPara_cpp2, 4},
     {"_quanteda_qatd_cpp_fcm", (DL_FUNC) &_quanteda_qatd_cpp_fcm, 8},
-    {"_quanteda_qatd_cpp_sequences", (DL_FUNC) &_quanteda_qatd_cpp_sequences, 6},
+    {"_quanteda_qatd_cpp_sequences", (DL_FUNC) &_quanteda_qatd_cpp_sequences, 7},
     {"_quanteda_qatd_cpp_tokens_compound", (DL_FUNC) &_quanteda_qatd_cpp_tokens_compound, 5},
     {"_quanteda_qatd_cpp_tokens_detect", (DL_FUNC) &_quanteda_qatd_cpp_tokens_detect, 2},
     {"_quanteda_qatd_cpp_kwic", (DL_FUNC) &_quanteda_qatd_cpp_kwic, 5},

--- a/src/sequences_mt_.cpp
+++ b/src/sequences_mt_.cpp
@@ -1,5 +1,5 @@
-//#include "dev.h"
 #include "quanteda.h"
+#include "dev.h"
 #include <bitset>
 using namespace quanteda;
 
@@ -77,32 +77,40 @@ double compute_dice(const std::vector<double> &counts){
     return dice;
 }
 
-//************************//
+
 void counts(Text text,
            MapNgrams &counts_seq,
-           SetNgrams &set_ignore,
+           SetUnigrams &set_ignore,
            const unsigned int &size){
 
-    
     if (text.size() == 0) return; // do nothing with empty text
-
-    std::size_t len_text = text.size();
     for (std::size_t i = 0; i < text.size() - size + 1; i++) {
-        //Rcout << "Size" << size << "\n";
-        // dev::print_ngram(text_sub);
         Text text_sub(text.begin() + i, text.begin() + i + size);
-        counts_seq[text_sub]++;
+        bool ignore = false;
+        for (std::size_t j = 0; j < text_sub.size(); j++) {
+            auto it = set_ignore.find(text_sub[j]);
+            if (it != set_ignore.end()) {
+                //Rcout << "i:" << i  << " j:" << j << "\n";
+                //dev::print_ngram(text_sub);
+                i += j; // jump
+                ignore = true;
+                break;
+            }
+        }
+        if (!ignore) {
+            counts_seq[text_sub]++;    
+        }
     }
 }
 
-struct counts_mt : public Worker{
+struct counts_mt : public Worker {
     
     Texts texts;
     MapNgrams &counts_seq;
-    SetNgrams &set_ignore;
+    SetUnigrams &set_ignore;
     const unsigned int &size;
 
-    counts_mt(Texts texts_, MapNgrams &counts_seq_, SetNgrams &set_ignore_, const unsigned int &size_):
+    counts_mt(Texts texts_, MapNgrams &counts_seq_, SetUnigrams &set_ignore_, const unsigned int &size_):
         texts(texts_), counts_seq(counts_seq_), set_ignore(set_ignore_), size(size_){}
     
     void operator()(std::size_t begin, std::size_t end){
@@ -128,7 +136,7 @@ void estimates(std::size_t i,
                const String &method,
                const int &count_min,
                const double nseqs,
-               const double smoothing){
+               const double smoothing) {
     
     std::size_t n = seqs_np[i].size(); //n=2:5, seqs
     if (n == 1) return; // ignore single words
@@ -137,7 +145,6 @@ void estimates(std::size_t i,
     std::vector<double> counts_bit(std::pow(2, n), smoothing);// use 1/2 as smoothing
     for (std::size_t j = 0; j < seqs.size(); j++) {
         //if (i == j) continue; // do not compare with itself
- 
         int bit;
         bit = match_bit2(seqs_np[i], seqs[j]);
         counts_bit[bit] += cs[j];
@@ -282,7 +289,7 @@ struct estimates_mt : public Worker{
 // [[Rcpp::export]]
 DataFrame qatd_cpp_sequences(const List &texts_,
                              const CharacterVector &types_,
-                             const List &words_ignore_,
+                             const IntegerVector &words_ignore_,
                              const unsigned int count_min,
                              const IntegerVector sizes_,
                              const String &method,
@@ -290,40 +297,28 @@ DataFrame qatd_cpp_sequences(const List &texts_,
     
     Texts texts = as<Texts>(texts_);
     std::vector<unsigned int> sizes = as< std::vector<unsigned int> >(sizes_);
+    std::vector<unsigned int> words_ignore = as< std::vector<unsigned int> >(words_ignore_);
 
-    SetNgrams set_ignore;
-    std::vector<std::size_t> spans = register_ngrams(words_ignore_, set_ignore);
+    SetUnigrams set_ignore;
+    set_ignore.max_load_factor(GLOBAL_PATTERNS_MAX_LOAD_FACTOR);
+    for (size_t g = 0; g < words_ignore.size(); g++) {
+        set_ignore.insert(words_ignore[g]);
+    }
    
     // Estimate significance of the sequences
     unsigned int len_coe = sizes.size() * types_.size();
-    std::vector<double> sgma_all;
+    std::vector<double> sgma_all, lmda_all, dice_all, pmi_all, logratio_all;
+    std::vector<double> chi2_all, gensim_all, lfmd_all, cs_all, ns_all;
+    
     sgma_all.reserve(len_coe);
-    
-    std::vector<double> lmda_all;
     lmda_all.reserve(len_coe);
-    
-    std::vector<double> dice_all;
     dice_all.reserve(len_coe);
-    
-    std::vector<double> pmi_all;
     pmi_all.reserve(len_coe);
-    
-    std::vector<double> logratio_all;
     logratio_all.reserve(len_coe);
-    
-    std::vector<double> chi2_all;
     chi2_all.reserve(len_coe);
-    
-    std::vector<double> gensim_all;
     gensim_all.reserve(len_coe);
-    
-    std::vector<double> lfmd_all;
     lfmd_all.reserve(len_coe);
-    
-    std::vector<int> cs_all;   // count of sequence
     cs_all.reserve(len_coe);
-    
-    std::vector<int> ns_all; //length of sequence
     ns_all.reserve(len_coe);
     
     VecNgrams seqs_all;
@@ -333,21 +328,21 @@ DataFrame qatd_cpp_sequences(const List &texts_,
     //std::vector<std::string> ob_all;
     //ob_all.reserve(len_coe);
     
-    for(unsigned int m = 0; m < sizes.size(); m++){
-        unsigned int mw_len = sizes[m];
+    for (unsigned int size : sizes) {
+        //unsigned int mw_len = sizes[m];
         // Collect all sequences of specified words
         MapNgrams counts_seq;
-        //dev::Timer timer;
-        //dev::start_timer("Count", timer);
-//#if QUANTEDA_USE_TBB
-//        counts_mt count_mt(texts, counts_seq, mw_len);
-//        parallelFor(0, texts.size(), count_mt);
-//#else
+        // dev::Timer timer;
+        // dev::start_timer("Count", timer);
+#if QUANTEDA_USE_TBB
+        counts_mt count_mt(texts, counts_seq, set_ignore, size);
+        parallelFor(0, texts.size(), count_mt);
+#else
         for (std::size_t h = 0; h < texts.size(); h++) {
-            counts(texts[h], counts_seq, set_ignore, mw_len);
+            counts(texts[h], counts_seq, set_ignore, size);
         }
-//#endif
-        //dev::stop_timer("Count", timer);
+#endif
+        // dev::stop_timer("Count", timer);
         
         // Separate map keys and values
         std::size_t len = counts_seq.size();
@@ -358,41 +353,32 @@ DataFrame qatd_cpp_sequences(const List &texts_,
         cs_np.reserve(len);
         cs.reserve(len);
         
-       
-
         double total_counts = 0.0;
-        std::size_t len_noPadding = 0;
+        std::size_t len_nopad = 0;
         for (auto it = counts_seq.begin(); it != counts_seq.end(); ++it) {
-            seqs.push_back(it -> first);
-            cs.push_back(it -> second);
-            total_counts += it -> second;
-            if (std::find(it -> first.begin() , it -> first.begin() + it -> first.size(), 0) == it -> first.begin() + it -> first.size()) 
-            {
-                seqs_np.push_back(it -> first);
-                cs_np.push_back(it -> second);
-                seqs_all.push_back(it -> first);
-                cs_all.push_back(it -> second);
-                ns_all.push_back(it -> first.size());
-                len_noPadding ++;
+            seqs.push_back(it->first);
+            cs.push_back(it->second);
+            total_counts += it->second;
+            if (std::find(it->first.begin(), it->first.end(), 0) == it->first.end()) {
+                seqs_np.push_back(it->first);
+                cs_np.push_back(it->second);
+                seqs_all.push_back(it->first);
+                cs_all.push_back(it->second);
+                ns_all.push_back(it->first.size());
+                len_nopad++;
             }
         }
         
         //output counts;
-        //std::vector<std::string> ob_n(len_noPadding);
-        
+        //std::vector<std::string> ob_n(len_nopad);
         
         // adjust total_counts of MW 
         total_counts += 4 * smoothing;
         
         // Estimate significance of the sequences
-        DoubleParams sgma(len_noPadding);
-        DoubleParams lmda(len_noPadding);
-        DoubleParams dice(len_noPadding);
-        DoubleParams pmi(len_noPadding);
-        DoubleParams logratio(len_noPadding);
-        DoubleParams chi2(len_noPadding);
-        DoubleParams gensim(len_noPadding);
-        DoubleParams lfmd(len_noPadding);
+        DoubleParams sgma(len_nopad), lmda(len_nopad), dice(len_nopad), pmi(len_nopad);
+        DoubleParams logratio(len_nopad), chi2(len_nopad), gensim(len_nopad), lfmd(len_nopad);
+        
         //dev::start_timer("Estimate", timer);
 #if QUANTEDA_USE_TBB
         estimates_mt estimate_mt(seqs_np, cs_np, seqs, cs, sgma, lmda, dice, pmi, logratio, chi2, gensim, lfmd, method, count_min, total_counts, smoothing);
@@ -403,17 +389,17 @@ DataFrame qatd_cpp_sequences(const List &texts_,
         }
 #endif
         //dev::stop_timer("Estimate", timer);
-        sgma_all.insert( sgma_all.end(), sgma.begin(), sgma.end() );
-        lmda_all.insert( lmda_all.end(), lmda.begin(), lmda.end() );
-        dice_all.insert( dice_all.end(), dice.begin(), dice.end() );
-        pmi_all.insert( pmi_all.end(), pmi.begin(), pmi.end() );
-        logratio_all.insert( logratio_all.end(), logratio.begin(), logratio.end() );
-        chi2_all.insert( chi2_all.end(), chi2.begin(), chi2.end() );
-        gensim_all.insert( gensim_all.end(), gensim.begin(), gensim.end() );
-        lfmd_all.insert( lfmd_all.end(), lfmd.begin(), lfmd.end() );
+        sgma_all.insert(sgma_all.end(), sgma.begin(), sgma.end());
+        lmda_all.insert(lmda_all.end(), lmda.begin(), lmda.end());
+        dice_all.insert(dice_all.end(), dice.begin(), dice.end());
+        pmi_all.insert(pmi_all.end(), pmi.begin(), pmi.end());
+        logratio_all.insert(logratio_all.end(), logratio.begin(), logratio.end());
+        chi2_all.insert(chi2_all.end(), chi2.begin(), chi2.end());
+        gensim_all.insert(gensim_all.end(), gensim.begin(), gensim.end());
+        lfmd_all.insert(lfmd_all.end(), lfmd.begin(), lfmd.end());
         
         //output counts
-        //ob_all.insert( ob_all.end(), ob_n.begin(), ob_n.end() );
+        //ob_all.insert(ob_all.end(), ob_n.begin(), ob_n.end());
         
     }
     
@@ -440,20 +426,17 @@ DataFrame qatd_cpp_sequences(const List &texts_,
 
 
 /***R
-
+require(quanteda)
 toks <- tokens(data_corpus_inaugural)
-toks <- tokens_select(toks, stopwords("english"), "remove", padding = TRUE)
+#toks <- tokens_select(toks, stopwords("english"), "remove", padding = TRUE)
+types <- attr(toks, 'types')
+id_ignore <- unlist(quanteda:::regex2id("^\\p{P}+$", types, 'regex', FALSE), use.names = FALSE)
 
-#toks <- tokens_select(toks, "^([A-Z][a-z\\-]{2,})", valuetype="regex", case_insensitive = FALSE, padding = TRUE)
-#types <- unique(as.character(toks))
-#out2 <- qatd_cpp_sequences(toks, types, 1, 2, "lambda1",0.5)
-#out3 <- qatd_cpp_sequences(toks, types, 1, 2, "lambda",0.5)
-#out4 <- qatd_cpp_sequences(toks, types, 1, 3, "lambda1",0.5)
-# out2$z <- out2$lambda / out2$sigma
-# out2$p <- 1 - stats::pnorm(out2$z)
+if (is.null(id_ignore)) id_ignore <- integer(0)
+(out <- qatd_cpp_sequences(toks, types, id_ignore, 1, 3, "lambda", 0.0))
+
 txt <- "A gains capital B C capital gains A B capital C capital gains tax gains tax gains B gains C capital gains tax"
-toks <- tokens(txt)
-types <- unique(as.character(toks))
-out2 <- qatd_cpp_sequences(toks, types, list(1, 2), 1, 3, "lambda", 0.0)
+toks2 <- tokens(txt)
+(out2 <- qatd_cpp_sequences(toks2, attr(toks2, 'types'), c(3), 1, 3, "lambda", 0.0))
 
 */

--- a/tests/testthat/test-textstat_collocations.R
+++ b/tests/testthat/test-textstat_collocations.R
@@ -5,10 +5,9 @@ context('test textstat_collocations.R')
 # 
 # Two functions: One for counting the expressions and one for calculating the statistics
 
-# ************************************************************8
+# ************************************************************
 
-MWEcounts <- function (candidate,text,stopword="xxxx") 
-{
+MWEcounts <- function (candidate,text,stopword="xxxx") {
     # Function for creating the 2^K table of yes/no occurrences 
     # in text (character vector) 
     # of words in a K-word candidate expression (character vector) 
@@ -62,8 +61,7 @@ MWEcounts <- function (candidate,text,stopword="xxxx")
 
 # ************************************************************8
 
-MWEstatistics <- function (counts, smooth=0.5) 
-{
+MWEstatistics <- function (counts, smooth=0.5) {
     # Function for calculating some association statistics for a 
     # K-word candidate expression 
     # The input is output from the function MWEcounts 
@@ -263,71 +261,32 @@ test_that("deprecated collocations function works", {
         textstat_collocations(txts, size = 2, min_count = 2)
     )
     expect_warning(
-        collocations(txts, size = 3, min_count = 2),
+        collocations(txts, size = 2, min_count = 2),
         "'collocations' is deprecated"
     )
     expect_warning(
-        sequences(txts, size = 3, min_count = 2),
+        sequences(txts, size = 2, min_count = 2),
         "'sequences' is deprecated"
     )
 })
 
-test_that("tokens_segment_by_punctuation works as expected", {
-    toks1 <- tokens(c("This: is a test", "Another test"))
-    toks2 <- tokens(c("This: is a test!", "Another test."))
-    toks3 <- tokens(c("This is a test", "Another test"))
-    
+test_that("textstat_collocations.tokens works ok with zero-length documents (#940)", {
+    txt <- c('I like good ice cream.', 'Me too!  I like good ice cream.', '')
+    toks <- tokens(tolower(txt), remove_punct = TRUE, remove_symbols = TRUE)
+
     expect_equal(
-        as.list(quanteda:::tokens_segment_by_punctuation(toks1)),
-        list(text1.1 = "This", text1.2 = c("is", "a", "test"), text2.1 = c("Another", "test"))
+        textstat_collocations(txt, size = 2, min_count = 2, tolower = TRUE)$collocation,
+        c("ice cream", "like good", "i like", "good ice")
     )
-    
+    ##   collocation count length   lambda        z
+    ## 1   ice cream     2      2 4.317488 2.027787
+    ## 2   like good     2      2 4.317488 2.027787
+    ## 3      i like     2      2 4.317488 2.027787
+    ## 4    good ice     2      2 4.317488 2.027787
+
     expect_equal(
-        as.list(quanteda:::tokens_segment_by_punctuation(toks2)),
-        list(text1.1 = "This", text1.2 = c("is", "a", "test"), text2.1 = c("Another", "test"))
-    )
-    
-    expect_equal(
-        as.list(quanteda:::tokens_segment_by_punctuation(toks3)),
-        list(text1 = c("This", "is", "a", "test"), text2 = c("Another", "test"))
-    )
-    
-    expect_equal(
-        as.character(quanteda:::tokens_segment_by_punctuation(tokens("One!?"))),
-        "One"
-    )
-    expect_equal(
-        as.list(quanteda:::tokens_segment_by_punctuation(tokens("%*!?"))),
-        list(text1 = character())
-    )
-    expect_equal(
-        as.list(quanteda:::tokens_segment_by_punctuation(as.tokens(list(d1 = letters[1:3], d2 = "")))),
-        list(d1 = c("a", "b", "c"), d2 = character())
-    )
-    expect_equal(
-        as.list(quanteda:::tokens_segment_by_punctuation(as.tokens(list(d1 = letters[1:3], d2 = "", d3 = c("", ""))))),
-        list(d1 = c("a", "b", "c"), d2 = character(), d3 = character())
+        textstat_collocations(toks, size = 2, min_count = 2)$collocation,
+        c("ice cream", "like good", "i like", "good ice")
     )
 })
-
-# Broken
-# test_that("textstat_collocations.tokens works ok with zero-length documents (#940)", {
-#     txt <- c('I like good ice cream.', 'Me too!  I like good ice cream.', '')
-#     toks <- tokens(tolower(txt), remove_punct = TRUE, remove_symbols = TRUE)
-#     
-#     expect_equal(
-#         textstat_collocations(txt, size = 2, min_count = 2, tolower = TRUE)$collocation,
-#         c("ice cream", "like good", "i like", "good ice")
-#     )
-#     ##   collocation count length   lambda        z
-#     ## 1   ice cream     2      2 4.317488 2.027787
-#     ## 2   like good     2      2 4.317488 2.027787
-#     ## 3      i like     2      2 4.317488 2.027787
-#     ## 4    good ice     2      2 4.317488 2.027787
-#     
-#     expect_equal(
-#         textstat_collocations(toks, size = 2, min_count = 2)$collocation,
-#         c("ice cream", "like good", "i like", "good ice")
-#     )
-# })
 


### PR DESCRIPTION
Add word_ignore to `qutd_cpp_sequences()` to skip punctuation without segmenting tokens (#956).