### PR TITLE
Drop unused keys to solve a bug found in #1011

### DIFF
--- a/R/tokens_lookup.R
+++ b/R/tokens_lookup.R
@@ -119,7 +119,8 @@ tokens_lookup.tokens <- function(x, dictionary, levels = 1:5,
     } else {
         if (!is.null(nomatch))
             warning("nomatch only applies if exclusive = TRUE")
-        x <- qatd_cpp_tokens_lookup(x, c(keys, types), values_id, keys_id, FALSE, 2)
+        keys_used <- unique(keys_id)
+        x <- qatd_cpp_tokens_lookup(x, c(keys[keys_used], types), values_id, match(keys_id, keys_used), FALSE, 2)
     }
     attr(x, "what") <- "dictionary"
     attr(x, "dictionary") <- dictionary

--- a/tests/testthat/test-tokens_lookup.R
+++ b/tests/testthat/test-tokens_lookup.R
@@ -366,7 +366,7 @@ test_that("dfm_lookup match the same words in exclusive = TRUE and FALSE, #970",
 
 })
 
-test_that("dfm_lookup works exclusive = FALSE, #970", {
+test_that("tokens_lookup works when exclusive = FALSE, #970", {
     
     dict <- dictionary(list(sequence1 = "a b", sequence2 = "x y", notseq = c("d", "e")))
     txt <- c(d1 = "a b c d e f g x y z",
@@ -380,5 +380,22 @@ test_that("dfm_lookup works exclusive = FALSE, #970", {
                       d3 = c("SEQUENCE2"),
                       d4 = c("f", "g"))
                  )
+    
+})
+
+test_that("tokens_lookup works when there is a key with non-existent values and when exclusive = FALSE, #1011", {
+    
+    dict <- dictionary(list(sequence1 = "a b", sequence2 = "x y", notseq = c("d", "e"), notexist = c("zzz")))
+    txt <- c(d1 = "a b c d e f g x y z",
+             d2 = "a c d x z",
+             d3 = "x y",
+             d4 = "f g")
+    toks <- tokens(txt)
+    expect_equal(as.list(tokens_lookup(toks, dict, exclusive = FALSE)),
+                 list(d1 = c("SEQUENCE1", "c", "NOTSEQ", "NOTSEQ", "f", "g", "SEQUENCE2", "z"), 
+                      d2 = c("a","c", "NOTSEQ", "x", "z"),
+                      d3 = c("SEQUENCE2"),
+                      d4 = c("f", "g"))
+    )
     
 })


### PR DESCRIPTION
```r
toks <- tokens("The shape of the car is not good, but the color is nice.") # neutral sentence
tokens_lookup(toks, dictionary = data_dictionary_LSD2015, exclusive = FALSE)

tokens from 1 document.
text1 :
 [1] "The"          "shape"        "of"           "the"          "car"          "is"           "NEG_POSITIVE" "POSITIVE"     ","           
[10] "but"          "the"          "color"        "is"           "POSITIVE"     "."    
```