### PR TITLE
Add corpus support for tibble tbl_df objects

### DIFF
--- a/R/corpus.R
+++ b/R/corpus.R
@@ -5,11 +5,11 @@
 #' \itemize{ 
 #' \item a \link{character} vector, consisting of one document per element; if 
 #'   the elements are named, these names will be used as document names.
-#' \item a \link{data.frame}, whose default document id is a variable identified
-#' by \code{docid_field}; the text of the document is a variable identified by
-#' \code{textid_field}; and other variables are imported as document-level
-#' meta-data.  This matches the format of data.frames constructed by the the
-#' \pkg{readtext} package.
+#' \item a \link{data.frame} (or a \pkg{tibble} \code{tbl_df}),
+#' whose default document id is a variable identified by \code{docid_field}; the
+#' text of the document is a variable identified by \code{textid_field}; and
+#' other variables are imported as document-level meta-data.  This matches the
+#' format of data.frames constructed by the the \pkg{readtext} package.
 #' \item a \link{kwic} object constructed by \code{\link{kwic}}.
 #' \item a \pkg{tm} \link[tm]{VCorpus} or \link[tm]{SimpleCorpus} class  object, 
 #'   with the fixed metadata 
@@ -234,6 +234,10 @@ corpus.data.frame <- function(x, docid_field = NULL, text_field = "text", metaco
     
     if (length(addedArgs <- list(...)))
         warning("Argument", ifelse(length(addedArgs)>1, "s ", " "), names(addedArgs), " not used.", sep = "")
+    
+    if ("tbl_df" %in% class(x)) {
+        x <- as.data.frame(x)
+    }
     
     args <- list(...)
     

--- a/man/corpus.Rd
+++ b/man/corpus.Rd
@@ -75,11 +75,11 @@ sources are:
 \itemize{ 
 \item a \link{character} vector, consisting of one document per element; if 
   the elements are named, these names will be used as document names.
-\item a \link{data.frame}, whose default document id is a variable identified
-by \code{docid_field}; the text of the document is a variable identified by
-\code{textid_field}; and other variables are imported as document-level
-meta-data.  This matches the format of data.frames constructed by the the
-\pkg{readtext} package.
+\item a \link{data.frame} (or a \pkg{tibble} \code{tbl_df}),
+whose default document id is a variable identified by \code{docid_field}; the
+text of the document is a variable identified by \code{textid_field}; and
+other variables are imported as document-level meta-data.  This matches the
+format of data.frames constructed by the the \pkg{readtext} package.
 \item a \link{kwic} object constructed by \code{\link{kwic}}.
 \item a \pkg{tm} \link[tm]{VCorpus} or \link[tm]{SimpleCorpus} class  object, 
   with the fixed metadata 

--- a/tests/testthat/test-corpus.R
+++ b/tests/testthat/test-corpus.R
@@ -287,3 +287,18 @@ test_that("internal documents fn works", {
         c(3, 3)
     )
 })
+
+test_that("corpus constructor works with tibbles", {
+    skip_if_not_installed("tibble")
+    dd <- tibble::data_frame(a=1:3, text=c("Hello", "quanteda", "world"))
+    expect_is(
+        corpus(dd),
+        "corpus"
+    )
+    expect_equal(
+        texts(corpus(dd)),
+        c(text1 = "Hello", text2 = "quanteda", text3 = "world")
+    )
+})
+
+


### PR DESCRIPTION
Adds support for corpus construction from **tibble** `data_frame` objects, plus unit tests.

This simply tests for a `data.frame` also being a `tbl_df` inside `corpus.data.frame()`, and if it is, coerces it to a `data.frame`. (KISS principle)

Fixes #1040.
