### PR TITLE
Hotfix collocation

### DIFF
--- a/src/sequences_mt_.cpp
+++ b/src/sequences_mt_.cpp
@@ -83,7 +83,7 @@ void counts(Text text,
            SetUnigrams &set_ignore,
            const unsigned int &size){
 
-    if (text.size() == 0) return; // do nothing with empty text
+    if (text.size() < size) return; // do nothing with very short text
     for (std::size_t i = 0; i < text.size() - size + 1; i++) {
         Text text_sub(text.begin() + i, text.begin() + i + size);
         bool ignore = false;

--- a/tests/testthat/test-textstat_collocations.R
+++ b/tests/testthat/test-textstat_collocations.R
@@ -290,3 +290,15 @@ test_that("textstat_collocations.tokens works ok with zero-length documents (#94
     )
 })
 
+test_that("textstat_collocations works when texts are shorter than size", {
+    toks <- tokens(c('a', 'bb', ''))
+    expect_equivalent(
+        textstat_collocations(toks, size = 2:3, min_count = 1, tolower = TRUE),
+        data.frame(collocation = character(0), 
+                   count = integer(0), 
+                   length = numeric(0),
+                   lambda = numeric(0),
+                   z = numeric(0),
+                   stringsAsFactors = FALSE))
+})
+


### PR DESCRIPTION
I notice that `textstat_collocations` stops and crashes in a infinite loop when at least one document is shorter than `size`. This is critical.