### PR TITLE
Fix GitHub language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,8 @@
-vignettes/*	linguist-documentation
-docs/*	linguist-documentation
-man/*	linguist-documentation
+# Fix GitHub Linguist language detection
+# docs/ and man/ are automatically excluded
+vignettes/*       linguist-documentation
+tests/**/*.html   linguist-generated
+inst/doc/quickstart.html    linguist-generated
 
 # Source files
 # ============
@@ -9,5 +11,5 @@ man/*	linguist-documentation
 *.rds       binary
 *.Rd        text
 *.Rdx       binary
-*.Rmd		text
-*.R  		text
+*.Rmd       text
+*.R         text


### PR DESCRIPTION
The `html` files not covered by `vignettes/*`were a few files in `tests` and `inst/doc/quickstart.html` which are automatically generated from `*.Rmd`.

The count gets heavily inflated because GH counts file size and RMarkdown bundles a lot of JS and CSS in the generated html files which makes a short Rmd-generated html ~300KB which is a lot more than even the longest plain text code file.

---

I should have added that I checked that new stats with the local version of GitHub Linguist (the Ruby gem they provide) which looks like this:

```
quanteda-fork [master] % ~/.gem/ruby/2.4.0/bin/linguist
86.99%  R
13.00%  C++
0.01%   C
```