### PR TITLE
Issue error for converting weighted dfm to a topic model format

### DIFF
--- a/R/convert.R
+++ b/R/convert.R
@@ -76,6 +76,11 @@ convert.dfm <- function(x, to = c("lda", "tm", "stm", "austin", "topicmodels", "
             stop("docvars must have the same number of rows as ndoc(x)")
     }
     
+    if ((to %in% c("stm", "lda", "topicmodels")) &&
+        (x@weightTf$scheme != "count" || x@weightDf$scheme != "unary")) {
+        stop("cannot convert a non-count dfm to a topic model format")
+    }
+    
     if (to == "tm") 
         return(dfm2tm(x))
     else if (to == "lda")
@@ -186,9 +191,23 @@ dfm2tm <- function(x, weighting = tm::weightTf) {
     if (!requireNamespace("slam", quietly = TRUE))
         stop("You must install the slam package installed for this conversion.")
     
+    if (!(x@weightTf$scheme == "count" && x@weightDf$scheme == "unary")) {
+        warning("converted DocumentTermMatrix will not have weight attributes set correctly")
+    }
     tm::as.DocumentTermMatrix(slam::as.simple_triplet_matrix(x),
                               weighting = weighting)
 }
+
+## TODO: 
+## Implement weight recordings for 
+## weightTfIdf
+## - attr(*, "weighting")= chr [1:2] "term frequency - inverse document frequency" "tf-idf"
+## - attr(*, "weighting")= chr [1:2] "term frequency - inverse document frequency (normalized)" "tf-idf"
+## weightTf
+## - attr(*, "weighting")= chr [1:2] "term frequency" "tf"
+## weightSMART
+## - attr(*, "weighting")= chr [1:2] "SMART ntc" "SMART"  (e.g.)
+
 
 #' @rdname convert-wrappers
 #' @details

--- a/R/dfm_weight.R
+++ b/R/dfm_weight.R
@@ -312,6 +312,7 @@ tfidf.default <- function(x, scheme_tf = "count", scheme_df = "inverse", base = 
 #' @export
 tfidf.dfm <- function(x, scheme_tf = "count", scheme_df = "inverse", base = 10, ...) {
     
+    attrs <- attributes(x)
     x <- as.dfm(x)
     args <- list(...)
     check_dots(args, names(formals(docfreq)))
@@ -327,6 +328,12 @@ tfidf.dfm <- function(x, scheme_tf = "count", scheme_df = "inverse", base = 10, 
     
     # replace just the non-zero values by product with idf
     x@x <- tfreq@x * dfreq[j]
+    
+    # record attributes
+    attributes(x, FALSE) <- attrs
+    x@weightTf <- tfreq@weightTf
+    x@weightDf <- c(list(scheme = scheme_df, base = base), args)
+    
     x
 }
 

--- a/tests/testthat/test-convert.R
+++ b/tests/testthat/test-convert.R
@@ -228,3 +228,16 @@ test_that("tm converter works under extreme situations", {
     tmdfm <- convert(as.dfm(cmatrix), to = "tm")
     expect_equivalent(as.matrix(tmdfm), cmatrix)
 })
+
+test_that("weighted dfm is not convertible to a topic model format (#1091)", {
+    err_msg <- "cannot convert a non-count dfm to a topic model format"
+
+    expect_error(convert(tf(d, "prop"), to = "stm"), err_msg)
+    expect_error(convert(tf(d, "prop"), to = "topicmodels"), err_msg)
+    expect_error(convert(tf(d, "prop"), to = "lda"), err_msg)
+    expect_error(convert(dfm_weight(d, "relfreq"), to = "stm"), err_msg)
+    expect_error(convert(dfm_weight(d, "logfreq"), to = "stm"), err_msg)
+    
+    expect_error(convert(dfm_weight(d, "tfidf"), to = "stm"), err_msg)
+    expect_error(convert(tfidf(d), to = "stm"), err_msg)
+})

--- a/tests/testthat/test-dfm_weight.R
+++ b/tests/testthat/test-dfm_weight.R
@@ -174,3 +174,23 @@ test_that("dfm_weight works with zero-frequency features (#929)", {
         tolerance = .001
     )
 })
+
+test_that("settings are recorded for tf-idf weightings", {
+    mytexts <- c(text1 = "The new law included a capital gains tax, and an inheritance tax.",
+                 text2 = "New York City has raised a taxes: an income tax and a sales tax.")
+    d <- dfm(mytexts, remove_punct = TRUE)
+    
+    expect_equal(dfm_weight(d, "tfidf")@weightTf[["scheme"]], "count")
+    expect_equal(dfm_weight(d, "tfidf")@weightDf[["scheme"]], "inverse")
+    expect_equal(dfm_weight(d, "tfidf")@weightDf[["base"]], 10)
+    
+    expect_equal(tfidf(d)@weightTf[["scheme"]], "count")
+    expect_equal(tfidf(d)@weightDf[["scheme"]], "inverse")
+    expect_equal(tfidf(d, base = 10)@weightDf[["base"]], 10)
+    expect_equal(tfidf(d, base = 2)@weightDf[["base"]], 2)
+    expect_equal(tfidf(d, scheme_tf = "prop", base = 2)@weightTf[["scheme"]], "prop")
+    expect_equal(tfidf(d, scheme_tf = "prop", base = 2)@weightDf[["base"]], 2)
+    
+    expect_equal(tfidf(d, scheme_df = "inversemax")@weightDf[["scheme"]], "inversemax")
+    expect_equal(tfidf(d, scheme_df = "inversemax", k = 1)@weightDf[["k"]], 1)
+})


### PR DESCRIPTION
- Solves #1091 
- Now correctly records weight (and other) attributes after `tfidf()`.